### PR TITLE
[obexd] Fix FTP directory creation. Fixes JB#9440

### DIFF
--- a/rpm/FTP-fix-directory-creation-failure.patch
+++ b/rpm/FTP-fix-directory-creation-failure.patch
@@ -1,0 +1,26 @@
+diff --git a/plugins/ftp.c b/plugins/ftp.c
+index ff4b761..63304ec 100644
+--- a/plugins/ftp.c
++++ b/plugins/ftp.c
+@@ -310,17 +310,17 @@ int ftp_setpath(struct obex_session *os, void *user_data)
+ 
+ 	err = verify_path(fullname);
+ 
+-	if (err < 0)
++	if (err == -ENOENT) {
++		goto not_found;
++	} else if (err < 0) {
+ 		goto done;
++	}
+ 
+ 	err = stat(fullname, &dstat);
+ 
+ 	if (err < 0) {
+ 		err = -errno;
+ 
+-		if (err == -ENOENT)
+-			goto not_found;
+-
+ 		DBG("stat: %s(%d)", strerror(-err), -err);
+ 
+ 		goto done;

--- a/rpm/obexd.spec
+++ b/rpm/obexd.spec
@@ -8,6 +8,7 @@ URL:        http://www.bluez.org/
 Source0:    http://www.kernel.org/pub/linux/bluetooth/obexd-%{version}.tar.gz
 Source1:    obexd-wrapper
 Source2:    obexd.conf
+Patch0:     FTP-fix-directory-creation-failure.patch
 BuildRequires:  automake, libtool
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(dbus-1)
@@ -41,6 +42,8 @@ Development files for %{name}.
 %prep
 %setup -q -n %{name}-%{version}/%{name}
 
+# FTP-fix-directory-creation-failure.patch
+%patch0 -p1
 
 %build
 ./bootstrap


### PR DESCRIPTION
plugins/filesystem.c function verify_path() returns -ENOENT if the path being checked does not exist. If this is not handled separately from other errors, directories cannot be created. 

Since the name used in creation request is already checked not to contain slashes or other directory name components by is_filename() it's guaranteed that the new directory will be under the current working directory and it's not possible to escape from under obex root. 
