### PR TITLE
[obexd] Configure plugins and OBEX root. Contributes to JB#8662.

### DIFF
--- a/rpm/obexd.conf
+++ b/rpm/obexd.conf
@@ -1,1 +1,27 @@
 OBEXD_ARGUMENTS="--capability !/usr/bin/obex-capability"
+
+for PREFIX in "" "no"
+do
+    if [ -d /etc/obexd/${PREFIX}plugins ]; then
+	PLUGINS=""
+
+	for PLUGIN in `find /etc/obexd/${PREFIX}plugins -type f`
+	do
+            if [ -z "${PLUGINS}" ]; then
+    		PLUGINS=`basename "${PLUGIN}"`
+	    else
+		PLUGINS="${PLUGINS}",`basename "${PLUGIN}"`
+	    fi
+	done
+
+	if [ ! -z "${PLUGINS}" ]; then
+            OBEXD_ARGUMENTS="${OBEXD_ARGUMENTS} --${PREFIX}plugin=${PLUGINS}"
+	fi
+    fi
+
+done
+
+if [ -f /etc/obexd/root ]; then
+    OBEXROOT=$(eval echo -e `cat /etc/obexd/root`)
+    OBEXD_ARGUMENTS="${OBEXD_ARGUMENTS} --root=${OBEXROOT}"
+fi


### PR DESCRIPTION
Modified the configuration script to look for enabled and disabled plugins, as well as OBEX root. This allows for more flexible configuration of OBEX daemon, e.g. by a configuration package that creates the files. 
