### PR TITLE
[obexd] Disconnect request at the end of client session. Fixes JB#9622.

### DIFF
--- a/rpm/OPP-disconnect-request-on-client-exit.patch
+++ b/rpm/OPP-disconnect-request-on-client-exit.patch
@@ -1,0 +1,97 @@
+diff --git a/client/session.c b/client/session.c
+index 1b6b927..15f5ac3 100644
+--- a/client/session.c
++++ b/client/session.c
+@@ -479,6 +479,24 @@ proceed:
+ 	return session;
+ }
+ 
++static void disconnect_cb(GObex *obex, GError *err, GObexPacket *rsp,
++							gpointer user_data)
++{
++	struct pending_request *p = user_data;
++	struct obc_session *session = p != NULL ? p->session : NULL;
++
++	DBG("Finalizing disconnection. ");
++
++	pending_request_free(p);
++
++	if (session != NULL && session->id > 0 && session->transport != NULL) {
++		session->transport->disconnect(session->id);
++		session->id = 0;
++	}
++
++	obc_session_unref(session);
++}
++
+ void obc_session_shutdown(struct obc_session *session)
+ {
+ 	struct pending_request *p;
+@@ -515,13 +533,25 @@ void obc_session_shutdown(struct obc_session *session)
+ 	if (session->path)
+ 		session_unregistered(session);
+ 
+-	/* Disconnect transport */
++	DBG("Checking the need for disconnect request");
++	/* Send a disconnect request and wait for reply */
+ 	if (session->id > 0 && session->transport != NULL) {
+-		session->transport->disconnect(session->id);
+-		session->id = 0;
++		DBG("Generating disconnect request. ");
++		err = NULL;
++		p = pending_request_new(session, NULL, NULL, NULL);
++		p->req_id = g_obex_disconnect(session->obex, disconnect_cb,
++						p, &err);
++		if (err != NULL) {
++			DBG("Generating disconnect request failed. ");
++			disconnect_cb(session->obex, NULL, NULL, p);
++		} else {
++			/* Finalize when reply arrives */
++			DBG("Generating disconnect request succeeded. ");
++		}
++	} else {
++		DBG("Unreferring without disconnect request.");
++		obc_session_unref(session);
+ 	}
+-
+-	obc_session_unref(session);
+ }
+ 
+ static DBusMessage *session_get_properties(DBusConnection *connection,
+diff --git a/gobex/gobex.c b/gobex/gobex.c
+index 7c136af..9cb1a64 100644
+--- a/gobex/gobex.c
++++ b/gobex/gobex.c
+@@ -1381,6 +1381,18 @@ guint g_obex_connect(GObex *obex, GObexResponseFunc func, gpointer user_data,
+ 	return g_obex_send_req(obex, req, -1, func, user_data, err);
+ }
+ 
++guint g_obex_disconnect(GObex *obex, GObexResponseFunc func,
++					gpointer user_data, GError **err)
++{
++	GObexPacket *req;
++
++	g_obex_debug(G_OBEX_DEBUG_COMMAND, "");
++
++	req = g_obex_packet_new(G_OBEX_OP_DISCONNECT, TRUE, G_OBEX_HDR_INVALID);
++
++	return g_obex_send_req(obex, req, -1, func, user_data, err);
++}
++
+ guint g_obex_setpath(GObex *obex, const char *path, GObexResponseFunc func,
+ 					gpointer user_data, GError **err)
+ {
+diff --git a/gobex/gobex.h b/gobex/gobex.h
+index 3120da2..d116183 100644
+--- a/gobex/gobex.h
++++ b/gobex/gobex.h
+@@ -76,6 +76,9 @@ void g_obex_unref(GObex *obex);
+ guint g_obex_connect(GObex *obex, GObexResponseFunc func, gpointer user_data,
+ 				GError **err, guint8 first_hdr_id, ...);
+ 
++guint g_obex_disconnect(GObex *obex, GObexResponseFunc func,
++					gpointer user_data, GError **err);
++
+ guint g_obex_setpath(GObex *obex, const char *path, GObexResponseFunc func,
+ 					gpointer user_data, GError **err);
+ 

--- a/rpm/obexd.spec
+++ b/rpm/obexd.spec
@@ -9,6 +9,7 @@ Source0:    http://www.kernel.org/pub/linux/bluetooth/obexd-%{version}.tar.gz
 Source1:    obexd-wrapper
 Source2:    obexd.conf
 Patch0:     FTP-fix-directory-creation-failure.patch
+Patch1:     OPP-disconnect-request-on-client-exit.patch
 BuildRequires:  automake, libtool
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(dbus-1)
@@ -44,6 +45,8 @@ Development files for %{name}.
 
 # FTP-fix-directory-creation-failure.patch
 %patch0 -p1
+# OPP-disconnect-request-on-client-exit.patch
+%patch1 -p1
 
 %build
 ./bootstrap


### PR DESCRIPTION
PTS test TC_CLIENT_OPH_BV-34-I requires that OBEX push client sends a disconnect request to the server, although IrOBEX standard allows the client to disconnect simply by closing the transport. 

Patch the push client to send a disconnect request and wait for a reply before closing the transport. If creating a disconnection request fails, just drop the transport; ignore whatever response headers are given by the server, they are not important as we're going away anyway. 

NB. Nokia N9 does send a disconnection request at the end of a client session: looks like this feature got lost somewhere between obexd 0.42 and 0.48.
