### PR TITLE
[obexd] Prevent double disconnect and null reference. Contributes to JB#...

### DIFF
--- a/rpm/OPP-disconnect-request-on-client-exit.patch
+++ b/rpm/OPP-disconnect-request-on-client-exit.patch
@@ -1,8 +1,24 @@
 diff --git a/client/session.c b/client/session.c
-index 1b6b927..15f5ac3 100644
+index 1b6b927..7916995 100644
 --- a/client/session.c
 +++ b/client/session.c
-@@ -479,6 +479,24 @@ proceed:
+@@ -97,6 +97,7 @@ struct obc_session {
+ 	guint watch;
+ 	GQueue *queue;
+ 	guint queue_complete_id;
++	gboolean disconnecting;
+ };
+ 
+ static GSList *sessions = NULL;
+@@ -463,6 +464,7 @@ struct obc_session *obc_session_create(const char *source,
+ 	session->destination = g_strdup(destination);
+ 	session->channel = channel;
+ 	session->queue = g_queue_new();
++	session->disconnecting = FALSE;
+ 
+ 	if (owner)
+ 		obc_session_set_owner(session, owner, owner_disconnected);
+@@ -479,6 +481,24 @@ proceed:
  	return session;
  }
  
@@ -27,16 +43,31 @@ index 1b6b927..15f5ac3 100644
  void obc_session_shutdown(struct obc_session *session)
  {
  	struct pending_request *p;
-@@ -515,13 +533,25 @@ void obc_session_shutdown(struct obc_session *session)
+@@ -486,6 +506,12 @@ void obc_session_shutdown(struct obc_session *session)
+ 
+ 	DBG("%p", session);
+ 
++	if (session->disconnecting == TRUE) {
++		DBG("%p already disconnecting", session);
++		return;
++	}
++	session->disconnecting = TRUE;
++
+ 	obc_session_ref(session);
+ 
+ 	/* Unregister any pending transfer */
+@@ -515,13 +541,26 @@ void obc_session_shutdown(struct obc_session *session)
  	if (session->path)
  		session_unregistered(session);
  
 -	/* Disconnect transport */
-+	DBG("Checking the need for disconnect request");
-+	/* Send a disconnect request and wait for reply */
- 	if (session->id > 0 && session->transport != NULL) {
+-	if (session->id > 0 && session->transport != NULL) {
 -		session->transport->disconnect(session->id);
 -		session->id = 0;
++	DBG("Checking the need for disconnect request");
++	/* Send a disconnect request and wait for reply */
++	if (session->id > 0 && session->transport != NULL
++			&& session->obex != NULL) {
 +		DBG("Generating disconnect request. ");
 +		err = NULL;
 +		p = pending_request_new(session, NULL, NULL, NULL);


### PR DESCRIPTION
...9622.

Previous patch did not consider that obc_session_shutdown() can be
called for more than one reason: it is called when the D-Bus client
that requested the OBEX session unregisters, but also when it leaves
D-Bus. This was not a problem before, but now that obex-client waits
for disconnection reply it may see both events.

Keeping track when disconnection is being executed with a flag
prevents trying to do it twice.

Also, don't send a disconnect request if we don't have
a valid OBEX handle.
