### PR TITLE
[obexd] Disable SRM. Fixes JB#9623.

### DIFF
--- a/rpm/OPP-disable-SRM.patch
+++ b/rpm/OPP-disable-SRM.patch
@@ -1,0 +1,13 @@
+diff --git a/gobex/gobex.c b/gobex/gobex.c
+index 7c136af..104c22e 100644
+--- a/gobex/gobex.c
++++ b/gobex/gobex.c
+@@ -1295,7 +1295,7 @@ GObex *g_obex_new(GIOChannel *io, GObexTransportType transport_type,
+ 		obex->write = write_stream;
+ 		break;
+ 	case G_OBEX_TRANSPORT_PACKET:
+-		obex->use_srm = TRUE;
++		/* obex->use_srm = TRUE; */
+ 		obex->read = read_packet;
+ 		obex->write = write_packet;
+ 		break;

--- a/rpm/obexd.spec
+++ b/rpm/obexd.spec
@@ -10,6 +10,7 @@ Source1:    obexd-wrapper
 Source2:    obexd.conf
 Patch0:     FTP-fix-directory-creation-failure.patch
 Patch1:     OPP-disconnect-request-on-client-exit.patch
+Patch2:     OPP-disable-SRM.patch
 BuildRequires:  automake, libtool
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(dbus-1)
@@ -47,6 +48,8 @@ Development files for %{name}.
 %patch0 -p1
 # OPP-disconnect-request-on-client-exit.patch
 %patch1 -p1
+# OPP-disable-SRM.patch
+%patch2 -p1
 
 %build
 ./bootstrap


### PR DESCRIPTION
Quick hack to ensure that client sends an abort when a transfer
is canceled. If SRM is enabled, aborting transfers seems buggy
if the D-Bus client cancels a transfer and immediately afterwards
releases its session.
