### PR TITLE
[obexd] Allow configuration of OPP format list. Contributes to JB#10159.

### DIFF
--- a/rpm/OPP-supported-format-list.patch
+++ b/rpm/OPP-supported-format-list.patch
@@ -1,0 +1,132 @@
+diff -Naur obexd.orig/plugins/opp.c obexd/plugins/opp.c
+--- obexd.orig/plugins/opp.c	2013-10-13 15:10:56.360073958 +0300
++++ obexd/plugins/opp.c	2013-10-13 16:31:49.944637250 +0300
+@@ -26,6 +26,8 @@
+ #include <config.h>
+ #endif
+ 
++#include <stdio.h>
++#include <stdlib.h>
+ #include <errno.h>
+ #include <string.h>
+ #include <unistd.h>
+@@ -60,7 +62,7 @@
+       </sequence>						\
+       <sequence>						\
+         <uuid value=\"0x0003\"/>				\
+-        <uint8 value=\"%u\" name=\"channel\"/>			\
++        <uint8 value=\"%%u\" name=\"channel\"/>			\
+       </sequence>						\
+       <sequence>						\
+         <uuid value=\"0x0008\"/>				\
+@@ -78,22 +80,16 @@
+   </attribute>							\
+ 								\
+   <attribute id=\"0x0100\">					\
+-    <text value=\"%s\" name=\"name\"/>				\
++    <text value=\"%%s\" name=\"name\"/>				\
+   </attribute>							\
+ 								\
+   <attribute id=\"0x0303\">					\
+     <sequence>							\
+-      <uint8 value=\"0x01\"/>					\
+-      <uint8 value=\"0x02\"/>					\
+-      <uint8 value=\"0x03\"/>					\
+-      <uint8 value=\"0x04\"/>					\
+-      <uint8 value=\"0x05\"/>					\
+-      <uint8 value=\"0x06\"/>					\
+-      <uint8 value=\"0xff\"/>					\
++%s%s%s%s%s%s%s							\
+     </sequence>							\
+   </attribute>							\
+   <attribute id=\"0x0200\">					\
+-    <uint16 value=\"%u\" name=\"psm\"/>				\
++    <uint16 value=\"%%u\" name=\"psm\"/>			\
+   </attribute>							\
+ </record>"
+ 
+@@ -221,7 +217,7 @@
+ 	.service = OBEX_OPP,
+ 	.channel = OPP_CHANNEL,
+ 	.port = OBEX_PORT_RANDOM,
+-	.record = OPP_RECORD,
++	.record = NULL,
+ 	.connect = opp_connect,
+ 	.progress = opp_progress,
+ 	.disconnect = opp_disconnect,
+@@ -233,12 +229,74 @@
+ 
+ static int opp_init(void)
+ {
+-	return obex_service_driver_register(&driver);
++	gboolean vcard21 = TRUE, vcard30 = TRUE, 
++		vcal10 = TRUE, ical20 = TRUE,
++		vnote = TRUE, vmsg = TRUE,
++		any = TRUE;
++	GKeyFile *config = NULL;
++	gchar **list = NULL;
++	int i;
++	int ret = 0;
++
++	config = g_key_file_new();
++	if (config == NULL)
++		goto init;
++
++	if (g_key_file_load_from_file(config, "/etc/obexd/opp.conf",
++					G_KEY_FILE_NONE, NULL) == FALSE)
++		goto init;
++
++	g_key_file_set_list_separator(config, ',');
++
++	list = g_key_file_get_string_list(config, "OPP", "DisableFormat",
++					NULL, NULL);
++
++	for (i = 0; list != NULL && list[i] != NULL; i++) {
++		if (g_str_equal(list[i], "vCard2.1"))
++			vcard21 = FALSE;
++		else if (g_str_equal(list[i], "vCard3.0"))
++			vcard30 = FALSE;
++		else if (g_str_equal(list[i], "vCal1.0"))
++			vcal10 = FALSE;
++		else if (g_str_equal(list[i], "iCal2.0"))
++			ical20 = FALSE;
++		else if (g_str_equal(list[i], "vNote"))
++			vnote = FALSE;
++		else if (g_str_equal(list[i], "vMessage"))
++			vmsg = FALSE;
++		else if (g_str_equal(list[i], "any"))
++			any = FALSE;
++	}
++
++init:
++	if (asprintf(&driver.record, OPP_RECORD,
++			vcard21 ? "      <uint8 value=\"0x01\"/>" : "",
++			vcard30 ? "      <uint8 value=\"0x02\"/>" : "",
++			vcal10  ? "      <uint8 value=\"0x03\"/>" : "",
++			ical20  ? "      <uint8 value=\"0x04\"/>" : "",
++			vnote   ? "      <uint8 value=\"0x05\"/>" : "",
++			vmsg    ? "      <uint8 value=\"0x06\"/>" : "",
++			any     ? "      <uint8 value=\"0xff\"/>" : "") < 0) {
++		driver.record = NULL;
++		ret = -ENOMEM;
++	}
++
++	g_strfreev(list);
++	g_key_file_free(config);
++
++	if (ret == 0)
++		ret = obex_service_driver_register(&driver);
++
++	return ret;
+ }
+ 
+ static void opp_exit(void)
+ {
+ 	obex_service_driver_unregister(&driver);
++	if (driver.record) {
++		free(driver.record);
++		driver.record = NULL;
++	}
+ }
+ 
+ OBEX_PLUGIN_DEFINE(opp, opp_init, opp_exit)

--- a/rpm/obexd.spec
+++ b/rpm/obexd.spec
@@ -11,6 +11,7 @@ Source2:    obexd.conf
 Patch0:     FTP-fix-directory-creation-failure.patch
 Patch1:     OPP-disconnect-request-on-client-exit.patch
 Patch2:     OPP-disable-SRM.patch
+Patch3:     OPP-supported-format-list.patch
 BuildRequires:  automake, libtool
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(dbus-1)
@@ -50,6 +51,8 @@ Development files for %{name}.
 %patch1 -p1
 # OPP-disable-SRM.patch
 %patch2 -p1
+# OPP-supported-format-list.patch
+%patch3 -p1
 
 %build
 ./bootstrap


### PR DESCRIPTION
Read a configuration file to determine supported formats list in OPP SDP record; by default all formats are supported.

Configuration file location should be read from under CONFIGDIR but at the moment our other configuration files aren't there either; should tune that separately at some point. 
