### PR TITLE
[obexd] Retry opening ttyGS0 if it's not there. Fixes JB#12429.

### DIFF
--- a/rpm/USB-retry-tty.patch
+++ b/rpm/USB-retry-tty.patch
@@ -1,0 +1,36 @@
+diff -Naur obexd.orig/plugins/usb.c obexd/plugins/usb.c
+--- obexd.orig/plugins/usb.c	2013-11-08 02:43:31.742839317 +0000
++++ obexd/plugins/usb.c	2013-11-08 03:42:53.292976355 +0000
+@@ -105,10 +105,12 @@
+ 	return FALSE;
+ }
+ 
++#define MAX_RETRIES 10
++
+ static int usb_connect(struct obex_server *server)
+ {
+ 	struct termios options;
+-	int fd, err, arg;
++	int fd, err, arg, r;
+ 	glong flags;
+ 
+ 	if (usb_reconnecting > 0) {
+@@ -120,9 +122,15 @@
+ 	if (usb_io != NULL)
+ 		return 0;
+ 
+-	fd = open(USB_DEVNODE, O_RDWR | O_NOCTTY);
+-	if (fd < 0)
+-		return fd;
++	for (r = 0; r < MAX_RETRIES; r++) {
++		fd = open(USB_DEVNODE, O_RDWR | O_NOCTTY);
++		if (fd >= 0)
++			break;
++		if (errno != ENOENT || r == MAX_RETRIES - 1)
++			return fd;
++		DBG("%s does not exist, retrying.", USB_DEVNODE);
++		usleep(100*1000);
++	}
+ 
+ 	flags = fcntl(fd, F_GETFL);
+ 	fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);

--- a/rpm/obexd.spec
+++ b/rpm/obexd.spec
@@ -13,6 +13,7 @@ Patch1:     OPP-disconnect-request-on-client-exit.patch
 Patch2:     OPP-disable-SRM.patch
 Patch3:     OPP-supported-format-list.patch
 Patch4:     OPP-version.patch
+Patch5:     USB-retry-tty.patch
 BuildRequires:  automake, libtool
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(dbus-1)
@@ -56,6 +57,8 @@ Development files for %{name}.
 %patch3 -p1
 # OPP-version.patch
 %patch4 -p1
+# USB-retry-tty.patch
+%patch5 -p1
 
 %build
 ./bootstrap


### PR DESCRIPTION
Opening of ttyGS0 triggered by usb mode change fails sometimes
because the file does not yet exist. Work around that by trying
a few times.
