### PR TITLE
[obexd] Close pipe fds after get capability object. Fixes JB#13818.

### DIFF
--- a/rpm/FTP-fix-close-pipe-fds-issue.patch
+++ b/rpm/FTP-fix-close-pipe-fds-issue.patch
@@ -1,0 +1,35 @@
+diff -Naur obexd.orig/plugins/filesystem.c obexd/plugins/filesystem.c
+--- obexd.orig/plugins/filesystem.c	2013-12-10 16:50:47.970010000 +0800
++++ obexd/plugins/filesystem.c	2013-12-10 17:04:18.000000000 +0800
+@@ -616,14 +616,29 @@
+ static ssize_t capability_read(void *object, void *buf, size_t count)
+ {
+ 	struct capability_object *obj = object;
+-
++	ssize_t length;
+ 	if (obj->buffer)
+ 		return string_read(obj->buffer, buf, count);
+ 
+ 	if (obj->pid >= 0)
+ 		return -EAGAIN;
+ 
+-	return read(obj->output, buf, count);
++	length = read(obj->output, buf, count);
++	
++	/*if "length == 0" means finish the read, so close pipe fds*/
++	if (length == 0){
++		DBG("Close output & err pipe fds");
++		if (obj->output > 0) {
++			close(obj->output);
++			obj->output = -1;
++		}
++		if (obj->err > 0) {
++			close(obj->err);
++			obj->err = -1;
++		}
++	}
++	
++	return length;
+ }
+ 
+ static int capability_close(void *object)

--- a/rpm/obexd.spec
+++ b/rpm/obexd.spec
@@ -14,6 +14,7 @@ Patch2:     OPP-disable-SRM.patch
 Patch3:     OPP-supported-format-list.patch
 Patch4:     OPP-version.patch
 Patch5:     USB-retry-tty.patch
+Patch6:     FTP-fix-close-pipe-fds-issue.patch
 BuildRequires:  automake, libtool
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(dbus-1)
@@ -59,6 +60,8 @@ Development files for %{name}.
 %patch4 -p1
 # USB-retry-tty.patch
 %patch5 -p1
+# FTP-fix-close-pipe-fds-issue.patch
+%patch6 -p1
 
 %build
 ./bootstrap


### PR DESCRIPTION
g_spawn_async_with_pipes() will create child process and two pipe
for output and err. Each pipe have two ends. One for child
process(write), one for parent process(read).
Parent process(obexd) should close the pipe which belongs to his
end after used it.
