### PR TITLE
[obexd] Close pipe fds after get capability object. Fixes JB#13818.

### DIFF
--- a/rpm/FTP-fix-close-pipe-fds-issue.patch
+++ b/rpm/FTP-fix-close-pipe-fds-issue.patch
@@ -1,0 +1,54 @@
+diff -Naur obexd.orig/plugins/filesystem.c obexd/plugins/filesystem.c
+--- obexd.orig/plugins/filesystem.c	2013-12-12 19:12:43.334303000 +0800
++++ obexd/plugins/filesystem.c	2013-12-12 19:21:36.000000000 +0800
+@@ -354,6 +354,26 @@
+ 	GString *buffer;
+ };
+ 
++/*This function should be called after get capability object are done.
++  Close output & err pipe fds and free struct capability_object        */
++static void capability_deallocation(struct capability_object *object )
++{
++	DBG("");
++	if (object->output > 0) {
++		close(object->output);
++		object->output = -1;
++	}
++	if (object->err > 0) {
++		close(object->err);
++		object->err = -1;
++	}
++	
++	if (object->buffer != NULL)
++		g_string_free(object->buffer, TRUE);
++
++	g_free(object);
++}
++
+ static void script_exited(GPid pid, int status, void *data)
+ {
+ 	struct capability_object *object = data;
+@@ -367,10 +387,8 @@
+ 
+ 	/* free the object if aborted */
+ 	if (object->aborted) {
+-		if (object->buffer != NULL)
+-			g_string_free(object->buffer, TRUE);
++		capability_deallocation(object);
+ 
+-		g_free(object);
+ 		return;
+ 	}
+ 
+@@ -646,10 +664,7 @@
+ 	return 0;
+ 
+ done:
+-	if (obj->buffer != NULL)
+-		g_string_free(obj->buffer, TRUE);
+-
+-	g_free(obj);
++	capability_deallocation(obj);
+ 
+ 	return err;
+ }

--- a/rpm/obexd.spec
+++ b/rpm/obexd.spec
@@ -14,6 +14,7 @@ Patch2:     OPP-disable-SRM.patch
 Patch3:     OPP-supported-format-list.patch
 Patch4:     OPP-version.patch
 Patch5:     USB-retry-tty.patch
+Patch6:     FTP-fix-close-pipe-fds-issue.patch
 BuildRequires:  automake, libtool
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(dbus-1)
@@ -59,6 +60,8 @@ Development files for %{name}.
 %patch4 -p1
 # USB-retry-tty.patch
 %patch5 -p1
+# FTP-fix-close-pipe-fds-issue.patch
+%patch6 -p1
 
 %build
 ./bootstrap


### PR DESCRIPTION
g_spawn_async_with_pipes() will create child process and two pipe
for output and err. Each pipe have two ends. One for child
process(write), one for parent process(read).
Parent process(obexd) should close the pipe which belongs to his
end after used it.
