### PR TITLE
obexd/irmc: Fix folder for LUID requests

### DIFF
--- a/rpm/IRMC-fix-folder-for-luid-requests.patch
+++ b/rpm/IRMC-fix-folder-for-luid-requests.patch
@@ -1,0 +1,13 @@
+diff --git a/obexd/plugins/phonebook.h b/obexd/plugins/phonebook.h
+index 441cff2..fff33c1 100644
+--- a/obexd/plugins/phonebook.h
++++ b/obexd/plugins/phonebook.h
+@@ -37,7 +37,7 @@
+ #define PB_CALLS_INCOMING_FOLDER "/telecom/ich"
+ #define PB_CALLS_MISSED_FOLDER "/telecom/mch"
+ #define PB_CALLS_OUTGOING_FOLDER "/telecom/och"
+-#define PB_LUID_FOLDER "/telecom/luid"
++#define PB_LUID_FOLDER "/telecom/pb/luid"
+ 
+ #define PB_CONTACTS "/telecom/pb.vcf"
+ #define PB_CALLS_COMBINED "/telecom/cch.vcf"

--- a/rpm/obexd.spec
+++ b/rpm/obexd.spec
@@ -15,6 +15,7 @@ Patch3:     OPP-supported-format-list.patch
 Patch4:     OPP-version.patch
 Patch5:     USB-retry-tty.patch
 Patch6:     FTP-fix-close-pipe-fds-issue.patch
+Patch7:     IRMC-fix-folder-for-luid-requests.patch
 BuildRequires:  automake, libtool
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(dbus-1)
@@ -62,6 +63,8 @@ Development files for %{name}.
 %patch5 -p1
 # FTP-fix-close-pipe-fds-issue.patch
 %patch6 -p1
+# IRMC-fix-folder-for-luid-requests.patch
+%patch7 -p1
 
 %build
 ./bootstrap


### PR DESCRIPTION
IrMC suport in obexd 0.48 is broken.
This patch fixes nemomobile bug 721.
The patch for is already upstream in bluez 5.14.
