### PR TITLE
[obexd] Filter files to be received programmatically. Contributes to JB#...

### DIFF
--- a/rpm/OPP-reject-unsupported.patch
+++ b/rpm/OPP-reject-unsupported.patch
@@ -1,0 +1,276 @@
+diff -Naur obexd.orig/configure.ac obexd/configure.ac
+--- obexd.orig/configure.ac	2014-03-13 12:38:46.220915629 +0200
++++ obexd/configure.ac	2014-03-13 12:39:11.392914718 +0200
+@@ -154,6 +154,17 @@
+ 
+ AC_SUBST([PHONEBOOK_DRIVER], [phonebook-${phonebook_driver}.c])
+ 
++contentfilter_driver=dummy
++AC_ARG_WITH(contentfilter, AC_HELP_STRING([--with-contentfilter=DRIVER], [select content filter driver]), [
++	if (test "${withval}" = "no"); then
++		contentfilter_driver=dummy;
++	else
++		contentfilter_driver=${withval};
++	fi
++])
++
++AC_SUBST([CONTENTFILTER_DRIVER], [contentfilter-${contentfilter_driver}.c])
++
+ AC_ARG_ENABLE(usb, AC_HELP_STRING([--enable-usb],
+ 				[enable USB plugin]), [
+ 	enable_usb=${enableval}
+diff -Naur obexd.orig/Makefile.am obexd/Makefile.am
+--- obexd.orig/Makefile.am	2014-03-13 12:38:46.220915629 +0200
++++ obexd/Makefile.am	2014-03-13 12:39:52.748913222 +0200
+@@ -59,7 +59,8 @@
+ 
+ builtin_modules += pbap
+ builtin_sources += plugins/pbap.c plugins/phonebook.h \
+-			plugins/vcard.h plugins/vcard.c
++			plugins/vcard.h plugins/vcard.c \
++			plugins/contentfilter.h
+ 
+ builtin_modules += mas
+ builtin_sources += plugins/mas.c plugins/messages.h \
+@@ -73,6 +74,7 @@
+ 
+ builtin_nodist += plugins/phonebook.c
+ builtin_nodist += plugins/messages.c
++builtin_nodist += plugins/contentfilter.c
+ 
+ libexec_PROGRAMS += src/obexd
+ 
+@@ -150,7 +152,9 @@
+ 			plugins/phonebook-dummy.c plugins/phonebook-ebook.c \
+ 			plugins/phonebook-tracker.c \
+ 			plugins/phonebook-sailfish.c \
+-			plugins/messages-dummy.c plugins/messages-tracker.c
++			plugins/messages-dummy.c plugins/messages-tracker.c \
++			plugins/contentfilter-dummy.c \
++			plugins/contentfilter-helperapp.c
+ 
+ DISTCHECK_CONFIGURE_FLAGS = --enable-client --enable-server
+ 
+@@ -167,6 +171,9 @@
+ plugins/messages.c: plugins/@MESSAGES_DRIVER@
+ 	$(AM_V_GEN)$(LN_S) @abs_top_srcdir@/$< $@
+ 
++plugins/contentfilter.c: plugins/@CONTENTFILTER_DRIVER@
++	$(AM_V_GEN)$(LN_S) @abs_top_srcdir@/$< $@
++
+ TESTS = unit/test-gobex-apparam unit/test-gobex-header unit/test-gobex-packet \
+ 				unit/test-gobex unit/test-gobex-transfer
+ 
+diff -Naur obexd.orig/plugins/contentfilter-dummy.c obexd/plugins/contentfilter-dummy.c
+--- obexd.orig/plugins/contentfilter-dummy.c	1970-01-01 02:00:00.000000000 +0200
++++ obexd/plugins/contentfilter-dummy.c	2014-03-13 12:39:11.392914718 +0200
+@@ -0,0 +1,39 @@
++/*
++ *  Plugin to accept or reject incoming content programmatically
++ *
++ *  Copyright (C) 2014  Jolla Ltd.
++ *
++ *
++ *  This program is free software; you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation; either version 2 of the License, or
++ *  (at your option) any later version.
++ *
++ *  This program is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with this program; if not, write to the Free Software
++ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
++ *
++ */
++
++#include <glib.h>
++#include "contentfilter.h"
++
++int contentfilter_init(void)
++{
++	return 0;
++}
++
++void contentfilter_exit(void)
++{
++}
++
++gboolean contentfilter_receive_file(const char *filename)
++{
++	/* Dummy contentfilter accepts all */
++	return TRUE;
++}
+diff -Naur obexd.orig/plugins/contentfilter.h obexd/plugins/contentfilter.h
+--- obexd.orig/plugins/contentfilter.h	1970-01-01 02:00:00.000000000 +0200
++++ obexd/plugins/contentfilter.h	2014-03-13 12:39:11.392914718 +0200
+@@ -0,0 +1,30 @@
++/*
++ *  Plugin to accept or reject incoming content programmatically
++ *
++ *  Copyright (C) 2014  Jolla Ltd.
++ *
++ *
++ *  This program is free software; you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation; either version 2 of the License, or
++ *  (at your option) any later version.
++ *
++ *  This program is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with this program; if not, write to the Free Software
++ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
++ *
++ */
++
++int contentfilter_init(void);
++void contentfilter_exit(void);
++
++/*
++ * Return TRUE if filter approves receiving the file specified by the
++ * given filename, FALSE otherwise.
++ */
++gboolean contentfilter_receive_file(const char *filename);
+diff -Naur obexd.orig/plugins/contentfilter-helperapp.c obexd/plugins/contentfilter-helperapp.c
+--- obexd.orig/plugins/contentfilter-helperapp.c	1970-01-01 02:00:00.000000000 +0200
++++ obexd/plugins/contentfilter-helperapp.c	2014-03-13 12:39:11.392914718 +0200
+@@ -0,0 +1,92 @@
++/*
++ *  Plugin to accept or reject incoming content programmatically
++ *
++ *  Copyright (C) 2014  Jolla Ltd.
++ *
++ *
++ *  This program is free software; you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License as published by
++ *  the Free Software Foundation; either version 2 of the License, or
++ *  (at your option) any later version.
++ *
++ *  This program is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with this program; if not, write to the Free Software
++ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
++ *
++ */
++
++#include <errno.h>
++#include <string.h>
++#include <stdlib.h>
++#include <unistd.h>
++#include <sys/types.h>
++#include <sys/wait.h>
++#include <glib.h>
++
++#include "log.h"
++#include "contentfilter.h"
++
++/* Helper app returns success (0) if the operation is acceptable,
++ * failure (1) otherwise. Command line arguments are as follows:
++ *
++ * --receive-file <filename> -- check file reception
++ */
++#define HELPER "/usr/libexec/obexd-contentfilter-helperapp"
++
++int contentfilter_init(void)
++{
++	DBG("");
++	return 0;
++}
++
++void contentfilter_exit(void)
++{
++	DBG("");
++}
++
++/*
++ * Execute the external helper application to determine whether file
++ * should be received or not. In the absence of the helper application
++ * behave as the dummy filter and accept anything.
++ */
++gboolean contentfilter_receive_file(const char *filename)
++{
++	pid_t p;
++
++	DBG("Checking '%s'", filename);
++
++	/* No helper to determine status -- revert to accepting everything */
++	if (access(HELPER, F_OK) < 0 && errno == ENOENT) {
++		DBG("No helper, accepting.");
++		return TRUE;
++	}
++
++	p = fork();
++
++	if (p < 0) { /* fail */
++		DBG("fork failed.");
++		return FALSE;
++	} else if (p > 0) { /* parent */
++		int status;
++		pid_t q = waitpid(p, &status, 0);
++		if (q == p && WIFEXITED(status) && WEXITSTATUS(status) == 0) {
++			DBG("'%s' accepted.", filename);
++			return TRUE; /* check succeeded */
++		}
++		DBG("'%s' rejected.", filename);
++		return FALSE; /* check failed */
++	} else { /* child */
++		if (execl(HELPER,
++				HELPER, "--receive-file", filename,
++				(char *)NULL) < 0) {
++			DBG("exec() failed, %s (%d).", strerror(errno), errno);
++			exit(EXIT_FAILURE);
++		}
++		return FALSE; /* not reached, just keep gcc happy */
++	}
++}
+diff -Naur obexd.orig/plugins/opp.c obexd/plugins/opp.c
+--- obexd.orig/plugins/opp.c	2014-03-13 12:38:46.220915629 +0200
++++ obexd/plugins/opp.c	2014-03-13 12:39:11.392914718 +0200
+@@ -42,6 +42,7 @@
+ #include "log.h"
+ #include "manager.h"
+ #include "filesystem.h"
++#include "contentfilter.h"
+ 
+ #define VCARD_TYPE "text/x-vcard"
+ #define VCARD_FILE CONFIGDIR "/vcard.vcf"
+@@ -125,6 +126,9 @@
+ 	if (t != NULL && !is_filename(t))
+ 		return -EBADR;
+ 
++	if (!contentfilter_receive_file(t))
++		return -EBADR;
++
+ 	if (obex_option_auto_accept()) {
+ 		folder = g_strdup(obex_option_root_folder());
+ 		name = g_strdup(obex_get_name(os));
+@@ -243,6 +247,10 @@
+ 	int ret = 0;
+ 	uint16_t version = 0x0100;
+ 
++	ret = contentfilter_init();
++	if (ret < 0)
++		return ret;
++
+ 	config = g_key_file_new();
+ 	if (config == NULL)
+ 		goto init;
+@@ -317,6 +325,7 @@
+ 		free(driver.record);
+ 		driver.record = NULL;
+ 	}
++	contentfilter_exit();
+ }
+ 
+ OBEX_PLUGIN_DEFINE(opp, opp_init, opp_exit)

--- a/rpm/obexd.spec
+++ b/rpm/obexd.spec
@@ -17,6 +17,7 @@ Patch5:     USB-retry-tty.patch
 Patch6:     FTP-fix-close-pipe-fds-issue.patch
 Patch7:     IRMC-fix-folder-for-luid-requests.patch
 Patch8:     PBAP-sailfish.patch
+Patch9:     OPP-reject-unsupported.patch
 BuildRequires:  automake, libtool
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(dbus-1)
@@ -68,13 +69,16 @@ Development files for %{name}.
 %patch7 -p1
 # PBAP-sailfish.patch
 %patch8 -p1
+# OPP-reject-unsupported.patch
+%patch9 -p1
 
 %build
 ./bootstrap
 sed -i 's/ovi_suite/pc_suite/' plugins/usb.c
 %reconfigure --disable-static \
     --enable-usb --enable-pcsuite \
-    --with-phonebook=sailfish
+    --with-phonebook=sailfish \
+    --with-contentfilter=helperapp
 
 make %{?jobs:-j%jobs}
 


### PR DESCRIPTION
...16243.

Tiny plugin for checking whether incoming files should be received or not.
Dummy plugin accepts all files; helperapp plugin calls an external helper
to make the decision. The helper can be implemented e.g. with libcontentaction
to determine if there's a handler for the file in the system.
