### PR TITLE
[obexd] Send unsupported media type error code. Fixes JB#17754.

### DIFF
--- a/rpm/OPP-unsupported-type-error-code.patch
+++ b/rpm/OPP-unsupported-type-error-code.patch
@@ -1,0 +1,24 @@
+diff -Naur obexd.orig/gobex/gobex.c obexd/gobex/gobex.c
+--- obexd.orig/gobex/gobex.c	2014-03-27 14:47:30.028613580 +0200
++++ obexd/gobex/gobex.c	2014-03-27 15:00:07.320645361 +0200
+@@ -1509,6 +1509,8 @@
+ 	case -ENOTEMPTY:
+ 	case -EEXIST:
+ 		return G_OBEX_RSP_PRECONDITION_FAILED;
++	case -EMEDIUMTYPE:
++		return G_OBEX_RSP_UNSUPPORTED_MEDIA_TYPE;
+ 	default:
+ 		return G_OBEX_RSP_INTERNAL_SERVER_ERROR;
+ 	}
+diff -Naur obexd.orig/plugins/opp.c obexd/plugins/opp.c
+--- obexd.orig/plugins/opp.c	2014-03-27 14:47:30.028613580 +0200
++++ obexd/plugins/opp.c	2014-03-27 14:56:27.736636146 +0200
+@@ -127,7 +127,7 @@
+ 		return -EBADR;
+ 
+ 	if (!contentfilter_receive_file(t))
+-		return -EBADR;
++		return -EMEDIUMTYPE;
+ 
+ 	if (obex_option_auto_accept()) {
+ 		folder = g_strdup(obex_option_root_folder());

--- a/rpm/obexd.spec
+++ b/rpm/obexd.spec
@@ -18,6 +18,7 @@ Patch6:     FTP-fix-close-pipe-fds-issue.patch
 Patch7:     IRMC-fix-folder-for-luid-requests.patch
 Patch8:     PBAP-sailfish.patch
 Patch9:     OPP-reject-unsupported.patch
+Patch10:    OPP-unsupported-type-error-code.patch
 BuildRequires:  automake, libtool
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(dbus-1)
@@ -71,6 +72,8 @@ Development files for %{name}.
 %patch8 -p1
 # OPP-reject-unsupported.patch
 %patch9 -p1
+# OPP-unsupported-type-error-code.patch
+%patch10 -p1
 
 %build
 ./bootstrap


### PR DESCRIPTION
Send a specific error code when rejecting unsupported content instead of a generic error.
