### PR TITLE
[obexd] Flush PBAP cache more often

### DIFF
--- a/rpm/PBAP-vcardlisting-cache-flush.patch
+++ b/rpm/PBAP-vcardlisting-cache-flush.patch
@@ -1,0 +1,104 @@
+diff -Naur obexd.orig/plugins/pbap.c obexd/plugins/pbap.c
+--- obexd.orig/plugins/pbap.c	2014-06-04 14:08:07.117316909 +0300
++++ obexd/plugins/pbap.c	2014-06-04 18:42:13.227496372 +0300
+@@ -111,6 +111,7 @@
+ struct cache {
+ 	gboolean valid;
+ 	uint32_t index;
++	char *path;
+ 	GSList *entries;
+ };
+ 
+@@ -208,8 +209,13 @@
+ 	return NULL;
+ }
+ 
+-static void cache_clear(struct cache *cache)
++static void invalidate_cache(struct cache *cache)
+ {
++	DBG("Invalidating cache.");
++	cache->valid = FALSE;
++	cache->index = 0;
++	g_free(cache->path);
++	cache->path = NULL;
+ 	g_slist_free_full(cache->entries, cache_entry_free);
+ 	cache->entries = NULL;
+ }
+@@ -602,6 +608,12 @@
+ 
+ 	pbap->params = params;
+ 
++	DBG("cache check NAME='%s', FOLDER='%s', CACHEPATH='%s', VALID=%s",
++		name,
++		pbap->folder ? pbap->folder : "<null>",
++		pbap->cache.path ? pbap->cache.path : "<null>",
++		pbap->cache.valid ? "yes" : "no");
++
+ 	if (g_ascii_strcasecmp(type, PHONEBOOK_TYPE) == 0) {
+ 		/* Always contains the absolute path */
+ 		if (g_path_is_absolute(name))
+@@ -609,6 +621,15 @@
+ 		else
+ 			path = g_build_filename("/", name, NULL);
+ 
++		if (!pbap->cache.valid) {
++			g_free(pbap->cache.path);
++			pbap->cache.path = g_strdup(path);
++		} else if (strcmp(path, pbap->cache.path)) {
++			DBG("'%s' != '%s'", path, pbap->cache.path);
++			invalidate_cache(&pbap->cache);
++			pbap->cache.path = g_strdup(path);
++		}
++
+ 	} else if (g_ascii_strcasecmp(type, VCARDLISTING_TYPE) == 0) {
+ 		/* Always relative */
+ 		if (!name || strlen(name) == 0)
+@@ -618,9 +639,28 @@
+ 			/* Current folder + relative path */
+ 			path = g_build_filename(pbap->folder, name, NULL);
+ 
++		if (!pbap->cache.valid) {
++			g_free(pbap->cache.path);
++			pbap->cache.path = g_strdup(path);
++		} else if (strcmp(path, pbap->cache.path)) {
++			DBG("'%s' != '%s'", path, pbap->cache.path);
++			invalidate_cache(&pbap->cache);
++			pbap->cache.path = g_strdup(path);
++		}
++
+ 	} else if (g_ascii_strcasecmp(type, VCARDENTRY_TYPE) == 0) {
+ 		/* File name only */
+ 		path = g_strdup(name);
++
++		if (!pbap->cache.valid) {
++			g_free(pbap->cache.path);
++			pbap->cache.path = g_strdup(pbap->folder);
++		} else if (strcmp(pbap->folder, pbap->cache.path)) {
++			DBG("'%s' != '%s'", pbap->folder, pbap->cache.path);
++			invalidate_cache(&pbap->cache);
++			pbap->cache.path = g_strdup(pbap->folder);
++		}
++
+ 	} else
+ 		return -EBADR;
+ 
+@@ -663,9 +703,7 @@
+ 	/*
+ 	 * FIXME: Define a criteria to mark the cache as invalid
+ 	 */
+-	pbap->cache.valid = FALSE;
+-	pbap->cache.index = 0;
+-	cache_clear(&pbap->cache);
++	invalidate_cache(&pbap->cache);
+ 
+ 	return 0;
+ }
+@@ -684,7 +722,7 @@
+ 		g_free(pbap->params);
+ 	}
+ 
+-	cache_clear(&pbap->cache);
++	invalidate_cache(&pbap->cache);
+ 	g_free(pbap->folder);
+ 	g_free(pbap);
+ }

--- a/rpm/obexd.spec
+++ b/rpm/obexd.spec
@@ -19,6 +19,7 @@ Patch7:     IRMC-fix-folder-for-luid-requests.patch
 Patch8:     PBAP-sailfish.patch
 Patch9:     OPP-reject-unsupported.patch
 Patch10:    OPP-unsupported-type-error-code.patch
+Patch11:    PBAP-vcardlisting-cache-flush.patch
 BuildRequires:  automake, libtool
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(dbus-1)
@@ -74,6 +75,8 @@ Development files for %{name}.
 %patch9 -p1
 # OPP-unsupported-type-error-code.patch
 %patch10 -p1
+# PBAP-vcardlisting-cache-flush.patch
+%patch11 -p1
 
 %build
 ./bootstrap


### PR DESCRIPTION
Since the PBAP cache is flushed only when a setpath operation is
performed, it may happen that a carkit moves to, say, /telecom/pb
using setpath, and then pulls incoming call history using absolute
path. This populates the cache with that data; if carkit then pulls
vcardlisting for something else, wrong cache data is used to generate
the listing.

Fix this by keeping track of what data was used to populate the cache,
and flush cache when request to some other data is made, in addition
to setpath flushing.
