### PR TITLE
[obexd] pbap: clean up any possible request at session disconnect

### DIFF
--- a/rpm/PBAP-request-cleanup.patch
+++ b/rpm/PBAP-request-cleanup.patch
@@ -1,0 +1,82 @@
+diff -Naur obexd.orig/plugins/pbap.c obexd/plugins/pbap.c
+--- obexd.orig/plugins/pbap.c	2014-11-05 10:15:09.025110346 +0200
++++ obexd/plugins/pbap.c	2014-11-05 10:15:22.149110833 +0200
+@@ -714,8 +714,13 @@
+ 
+ 	manager_unregister_session(os);
+ 
+-	if (pbap->obj)
++	if (pbap->obj) {
++		if (pbap->obj->request) {
++			phonebook_req_finalize(pbap->obj->request);
++			pbap->obj->request = NULL;
++		}
+ 		pbap->obj->session = NULL;
++	}
+ 
+ 	if (pbap->params) {
+ 		g_free(pbap->params->searchval);
+@@ -818,14 +823,20 @@
+ 	if (obj->session)
+ 		obj->session->obj = NULL;
+ 
+-	if (obj->buffer)
++	if (obj->buffer) {
+ 		g_string_free(obj->buffer, TRUE);
++		obj->buffer = NULL;
++	}
+ 
+-	if (obj->apparam)
++	if (obj->apparam) {
+ 		g_obex_apparam_free(obj->apparam);
++		obj->apparam = NULL;
++	}
+ 
+-	if (obj->request)
++	if (obj->request) {
+ 		phonebook_req_finalize(obj->request);
++		obj->request = NULL;
++	}
+ 
+ 	g_free(obj);
+ 
+diff -Naur obexd.orig/plugins/phonebook-sailfish.c obexd/plugins/phonebook-sailfish.c
+--- obexd.orig/plugins/phonebook-sailfish.c	2014-11-05 10:15:09.025110346 +0200
++++ obexd/plugins/phonebook-sailfish.c	2014-11-05 10:55:32.717200369 +0200
+@@ -676,6 +676,8 @@
+ 				cb,
+ 				data,
+ 				NULL);
++	dbus_message_unref(msg);
++
+ 	return 0;
+ }
+ 
+@@ -749,6 +751,7 @@
+ 				fetch_one_cb, 
+ 				data,
+ 				NULL);
++	dbus_message_unref(msg);
+ 
+ 	if (err)
+ 		*err = 0;
+@@ -829,6 +832,7 @@
+ 				fetch_many_cb,
+ 				data,
+ 				NULL);
++	dbus_message_unref(msg);
+ 
+ 	if (err)
+ 		*err = 0;
+@@ -845,8 +849,10 @@
+ 	if (!data)
+ 		return;
+ 
+-	if (data->pend != NULL)
++	if (data->pend != NULL) {
+ 		dbus_pending_call_cancel(data->pend);
++		dbus_pending_call_unref(data->pend);
++	}
+ 
+ 	g_free(data->pull_buf);
+ 	g_free(data->name);

--- a/rpm/obexd.spec
+++ b/rpm/obexd.spec
@@ -21,6 +21,7 @@ Patch9:     OPP-reject-unsupported.patch
 Patch10:    OPP-unsupported-type-error-code.patch
 Patch11:    PBAP-vcardlisting-cache-flush.patch
 Patch12:    FIX-compilation-gcc483.patch
+Patch13:    PBAP-request-cleanup.patch
 BuildRequires:  automake, libtool
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(dbus-1)
@@ -80,6 +81,8 @@ Development files for %{name}.
 %patch11 -p1
 # FIX-compilation-gcc483.patch
 %patch12 -p1
+# PBAP-request-cleanup.patch
+%patch13 -p1
 %build
 ./bootstrap
 sed -i 's/ovi_suite/pc_suite/' plugins/usb.c


### PR DESCRIPTION
Make sure that requests are cleaned (and associated D-Bus method calls
cancelled) on disconnect. Also added pointer clearing to the cleanup
code so that freed memory won't be considered still valid by mistake.
