### PR TITLE
Ftp blacklist

### DIFF
--- a/obexd/Makefile.am
+++ b/obexd/Makefile.am
@@ -51,6 +51,11 @@ builtin_modules += pcsuite
 builtin_sources += plugins/pcsuite.c
 endif
 
+if JOLLA_BLACKLIST
+builtin_modules += jolla_blacklist
+builtin_sources += plugins/jolla-blacklist.c
+endif
+
 builtin_modules += opp
 builtin_sources += plugins/opp.c
 

--- a/obexd/Makefile.am
+++ b/obexd/Makefile.am
@@ -86,7 +86,7 @@ src_obexd_SOURCES = $(gdbus_sources) $(builtin_sources) $(btio_sources) \
 			src/mimetype.h src/mimetype.c \
 			src/service.h src/service.c \
 			src/transport.h src/transport.c \
-			src/server.h src/server.c
+			src/server.h src/server.c src/access.c
 
 src_obexd_LDADD = @DBUS_LIBS@ @GLIB_LIBS@ @GTHREAD_LIBS@ \
 					@EBOOK_LIBS@ @BLUEZ_LIBS@ \

--- a/obexd/Makefile.am
+++ b/obexd/Makefile.am
@@ -217,3 +217,13 @@ noinst_PROGRAMS += tools/test-server
 tools_test_server_SOURCES = $(gobex_sources) $(btio_sources) \
 							tools/test-server.c
 tools_test_server_LDADD = @GLIB_LIBS@ @BLUEZ_LIBS@
+
+if JOLLA_BLACKLIST
+TESTS += unit/test-jolla-blacklist
+noinst_PROGRAMS += unit/test-jolla-blacklist
+
+unit_test_jolla_blacklist_SOURCES = src/access.c src/access.h \
+					src/log.c src/log.h \
+						unit/test-jolla-blacklist.c
+unit_test_jolla_blacklist_LDADD = @GLIB_LIBS@
+endif

--- a/obexd/configure.ac
+++ b/obexd/configure.ac
@@ -191,4 +191,10 @@ AM_CONDITIONAL(CLIENT, test "${enable_client}" != "no")
 
 AM_CONDITIONAL(READLINE, test "${readline_found}" = "yes")
 
+AC_ARG_ENABLE(jolla-blacklist, AC_HELP_STRING([--enable-jolla-blacklist],
+				[enable jolla-blacklist plugin]), [
+	enable_jolla_blacklist=${enableval}
+])
+AM_CONDITIONAL(JOLLA_BLACKLIST, test "${enable_jolla_blacklist}" = "yes")
+
 AC_OUTPUT(Makefile)

--- a/obexd/plugins/filesystem.c
+++ b/obexd/plugins/filesystem.c
@@ -47,6 +47,7 @@
 #include "log.h"
 #include "mimetype.h"
 #include "filesystem.h"
+#include "access.h"
 
 #define EOL_CHARS "\n"
 
@@ -169,6 +170,21 @@ static void *filesystem_open(const char *name, int oflag, mode_t mode,
 	struct statvfs buf;
 	int fd, ret;
 	uint64_t avail;
+	enum access_op op;
+
+	if (oflag & O_CREAT)
+		op = ACCESS_OP_CREATE;
+	else if ((oflag & O_WRONLY) || (oflag & O_RDWR))
+		op = ACCESS_OP_WRITE;
+	else
+		op = ACCESS_OP_READ;
+
+	ret = access_check(FTP_TARGET, FTP_TARGET_SIZE, op, name);
+	if (ret < 0) {
+		if (err)
+			*err = ret;
+		return NULL;
+	}
 
 	fd = open(name, oflag, mode);
 	if (fd < 0) {
@@ -253,9 +269,41 @@ static ssize_t filesystem_write(void *object, const void *buf, size_t count)
 	return ret;
 }
 
+static int filesystem_remove(const char *name)
+{
+	int ret;
+
+	ret = access_check(FTP_TARGET, FTP_TARGET_SIZE, ACCESS_OP_DELETE, name);
+	if (ret < 0) {
+		error("remove(%s, %s): %s (%d)", name, name,
+						strerror(-ret), -ret);
+		return ret;
+	}
+
+	if (remove(name) < 0)
+		return -errno;
+
+	return 0;
+}
+
 static int filesystem_rename(const char *name, const char *destname)
 {
 	int ret;
+
+	ret = access_check(FTP_TARGET, FTP_TARGET_SIZE, ACCESS_OP_DELETE, name);
+	if (ret < 0) {
+		error("rename(%s, %s): %s (%d)", name, destname,
+						strerror(-ret), -ret);
+		return ret;
+	}
+
+	ret = access_check(FTP_TARGET, FTP_TARGET_SIZE, ACCESS_OP_CREATE,
+			destname);
+	if (ret < 0) {
+		error("rename(%s, %s): %s (%d)", name, destname,
+						strerror(-ret), -ret);
+		return ret;
+	}
 
 	ret = rename(name, destname);
 	if (ret < 0) {
@@ -429,6 +477,9 @@ static void *capability_open(const char *name, int oflag, mode_t mode,
 	if (oflag != O_RDONLY)
 		goto fail;
 
+	if (access_check(FTP_TARGET, FTP_TARGET_SIZE, ACCESS_OP_READ, name) < 0)
+		goto fail;
+
 	object = g_new0(struct capability_object, 1);
 	object->pid = -1;
 	object->output = -1;
@@ -492,11 +543,18 @@ static GString *append_listing(GString *object, const char *name,
 {
 	struct stat fstat, dstat;
 	struct dirent *ep;
-	DIR *dp;
+	DIR *dp = NULL;
 	gboolean root;
 	int ret;
 
 	root = g_str_equal(name, obex_option_root_folder());
+
+	ret = access_check(FTP_TARGET, FTP_TARGET_SIZE, ACCESS_OP_READ, name);
+	if (ret < 0) {
+		if (err)
+			*err = ret;
+		goto failed;
+	}
 
 	dp = opendir(name);
 	if (dp == NULL) {
@@ -527,6 +585,10 @@ static GString *append_listing(GString *object, const char *name,
 		char *line;
 
 		if (ep->d_name[0] == '.')
+			continue;
+
+		if (access_check_at(FTP_TARGET, FTP_TARGET_SIZE, ACCESS_OP_LIST,
+					name, ep->d_name) < 0)
 			continue;
 
 		filename = g_filename_to_utf8(ep->d_name, -1, NULL, NULL, NULL);
@@ -674,7 +736,7 @@ static struct obex_mime_type_driver file = {
 	.close = filesystem_close,
 	.read = filesystem_read,
 	.write = filesystem_write,
-	.remove = remove,
+	.remove = filesystem_remove,
 	.move = filesystem_rename,
 	.copy = filesystem_copy,
 };

--- a/obexd/plugins/ftp.c
+++ b/obexd/plugins/ftp.c
@@ -49,6 +49,7 @@
 #include "service.h"
 #include "ftp.h"
 #include "filesystem.h"
+#include "access.h"
 
 #define LST_TYPE "x-obex/folder-listing"
 #define CAP_TYPE "x-obex/capability"
@@ -195,8 +196,7 @@ static int ftp_delete(struct ftp_session *ftp, const char *name)
 
 	path = g_build_filename(ftp->folder, name, NULL);
 
-	if (obex_remove(ftp->os, path) < 0)
-		ret = -errno;
+	ret = obex_remove(ftp->os, path);
 
 	g_free(path);
 
@@ -319,6 +319,12 @@ int ftp_setpath(struct obex_session *os, void *user_data)
 		goto done;
 	}
 
+	err = access_check(FTP_TARGET, TARGET_SIZE, ACCESS_OP_READ, fullname);
+	if (err < 0) {
+		DBG("access_check: %s(%d)", strerror(-err), -err);
+		goto done;
+	}
+
 	err = stat(fullname, &dstat);
 
 	if (err < 0) {
@@ -341,6 +347,12 @@ int ftp_setpath(struct obex_session *os, void *user_data)
 not_found:
 	if (nonhdr[0] != 0) {
 		err = -ENOENT;
+		goto done;
+	}
+
+	err = access_check(FTP_TARGET, TARGET_SIZE, ACCESS_OP_WRITE, fullname);
+	if (err < 0) {
+		DBG("access_check: %s(%d)", strerror(-err), -err);
 		goto done;
 	}
 

--- a/obexd/plugins/jolla-blacklist.c
+++ b/obexd/plugins/jolla-blacklist.c
@@ -1,0 +1,766 @@
+/*
+ *  Blacklist based file access control
+ *
+ *  Copyright (C) 2015 Jolla Ltd.
+ *  Contact: Hannu Mallat <hannu.mallat@jollamobile.com>
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdint.h>
+
+#include <glib.h>
+
+#include "log.h"
+#include "access.h"
+#include "plugin.h"
+
+#define CONFIG_DIR "/etc/fsstorage.d"
+#define CONFIG_SUFFIX ".xml"
+#define CONFIG_SUFFIX_LEN 4
+
+/*
+   Use GMarkup which is limited but good enough for our purposes of
+   parsing XML configuration files.
+
+   XML file should contain a <storage> element and possible
+   <blacklist> element(s) within. Anything unexpected or unrecognized,
+   including unexpected text, will be treated as an error.
+
+   Blacklist element text points to a file which contains blacklist
+   data to be applied under storage path.
+
+   Blacklist data may point to individual files as well as
+   directories, meaning for the latter than any file under that path
+   is blacklisted.
+
+*/
+
+struct blacklist_data {
+	gchar *path;
+	GPtrArray *elem;
+};
+
+#define PARSER_STACK_MAX 4
+
+enum config_elem {
+	CONFIG_ELEM_ROOT,
+	CONFIG_ELEM_STORAGE,
+	CONFIG_ELEM_BLACKLIST,
+
+	N_CONFIG_ELEM
+};
+
+struct blacklist_config {
+	gchar *storage_path;
+	gchar *blacklist_file;
+};
+
+struct parser_state {
+	enum config_elem stack[PARSER_STACK_MAX];
+	gsize pos;
+	gchar *storage_path;
+	gchar *blacklist_file;
+	GSList *configs;
+};
+
+typedef void (*parser_start_fn)(struct parser_state *state,
+				const gchar **attribute_names,
+				const gchar **attribute_values,
+				GError **error);
+
+typedef void (*parser_end_fn)(struct parser_state *state,
+				GError **error);
+
+static void start_storage(struct parser_state *state,
+				const gchar **attribute_names,
+				const gchar **attribute_values,
+				GError **error);
+
+static void start_blacklist(struct parser_state *state,
+				const gchar **attribute_names,
+				const gchar **attribute_values,
+				GError **error);
+
+static void end_storage(struct parser_state *state,
+				GError **error);
+
+static void end_blacklist(struct parser_state *state,
+				GError **error);
+
+static parser_start_fn start_transition[N_CONFIG_ELEM][N_CONFIG_ELEM] = {
+	{ NULL, start_storage, NULL },
+	{ NULL, NULL, start_blacklist },
+	{ NULL, NULL, NULL },
+};
+
+static parser_end_fn end_transition[N_CONFIG_ELEM] = {
+	NULL, end_storage, end_blacklist
+};
+
+static const gchar *config_elem_name[N_CONFIG_ELEM] = {
+	"document root", "storage", "blacklist"
+};
+
+static GSList *blacklists = NULL;
+
+static gchar *config_dir = NULL;
+
+static gchar *trimmed_string(const gchar *string)
+{
+	const gchar *s = string, *e = string + strlen(string);
+
+	while (g_ascii_isspace(*s)) s++;
+
+	while (e > s && g_ascii_isspace(*(e - 1))) e--;
+
+	if (s < e)
+		return g_strndup(s, e - s);
+
+	return NULL;
+}
+
+static gchar *memrchr(gchar *s, int c, int n)
+{
+	int i;
+
+	for (i = n; i > 0; i--)
+		if (s[i - 1] == c)
+			return &s[i - 1];
+	return NULL;
+}
+
+/* Quick and dirty absolute path string fixing, mostly to avoid config
+   typos.  Would like to use realpath() but that requires that file
+   actually exists at the time of the check. The following is done:
+   consecutive slashes are compressed, "./" (or trailing ".") erased,
+   "../" (or trailing "..") moves up one level (up to root). */
+static gchar *normalized_path(const gchar *path)
+{
+	gchar *result = NULL;
+	gchar *p, *r;
+
+	DBG("'%s'", path);
+
+	if (!path || *path != G_DIR_SEPARATOR)
+		goto out;
+
+	/* No modification lengthens the result, so we get away with this */
+	result = g_strdup(path);
+	p = result;
+	r = result;
+
+	while (1) {
+		gchar *q;
+
+		while (*p == G_DIR_SEPARATOR)
+			p++;
+
+		q = strchr(p, G_DIR_SEPARATOR);
+		if (!q)
+			q = p + strlen(p);
+
+		if (q == p) {
+			break;
+		} else if (q - p == 1 && p[0] == '.') {
+			/* . -> skip */
+		} else if (q - p == 2 && p[0] == '.' && p[1] == '.') {
+			/* .. -> back up one component if possible */
+			char *s = memrchr(result, G_DIR_SEPARATOR, r - result);
+			r = s > result ? s : result;
+		} else {
+			*r++ = G_DIR_SEPARATOR;
+			memmove(r, p, q - p);
+			r += q - p;
+		}
+
+		if (*q == '\0')
+			break;
+		p = q + 1;
+	}
+
+	if (r == result)
+		*r++ = G_DIR_SEPARATOR;
+
+	*r = '\0';
+
+out:
+	return result;
+}
+
+static void blacklist_debug(void)
+{
+	GSList *b;
+	gsize i;
+
+	for (b = blacklists; b; b = b->next) {
+		struct blacklist_data *data = b->data;
+		DBG("'%s'", data->path);
+		for (i = 0; i < data->elem->len; i++) {
+			DBG("\t%s", (gchar *)data->elem->pdata[i]);
+		}
+	}
+}
+
+static void blacklist_data_free(struct blacklist_data *data)
+{
+	g_ptr_array_unref(data->elem);
+	g_free(data->path);
+	g_free(data);
+}
+
+static void blacklist_clear(void)
+{
+	g_slist_free_full(blacklists, (GDestroyNotify)blacklist_data_free);
+	blacklists = NULL;
+}
+
+static int blacklist_add(const gchar *storage_path,
+			const gchar *blacklist_file)
+{
+	struct blacklist_data *data = NULL;
+	GPtrArray *elem = NULL;
+	GIOChannel *chan = NULL;
+	gboolean done = FALSE;
+	int r;
+
+	if (!storage_path || !blacklist_file) {
+		r = -EINVAL;
+		goto out;
+	}
+
+	DBG("'%s' -> '%s'", storage_path, blacklist_file);
+
+	chan = g_io_channel_new_file(blacklist_file, "r", NULL);
+	if (!chan) {
+		DBG("Cannot open blacklist file '%s'", blacklist_file);
+		r = -EIO;
+		goto out;
+	}
+
+	data = g_new0(struct blacklist_data, 1);
+	data->path = normalized_path(storage_path);
+
+	elem = g_ptr_array_new_with_free_func(g_free);
+	while(!done) {
+		/* #-lines are comments; rest is content that is trimmed */
+		gchar *line = NULL;
+
+		switch (g_io_channel_read_line(chan, &line, NULL, NULL, NULL)) {
+
+		case G_IO_STATUS_AGAIN:
+			break;
+
+		case G_IO_STATUS_NORMAL:
+			if (!line) {
+				DBG("Error reading blacklist data '%s'",
+					blacklist_file);
+				r = -EIO;
+				goto out;
+			}
+
+			if (*line != '#') {
+				gchar *trim = trimmed_string(line);
+				if (trim)
+					g_ptr_array_add(elem, trim);
+			}
+
+			g_free(line);
+
+			break;
+
+		case G_IO_STATUS_EOF:
+			data->elem = elem;
+			blacklists = g_slist_append(blacklists, data);
+			elem = NULL;
+			data = NULL;
+			done = TRUE;
+			break;
+
+		case G_IO_STATUS_ERROR:
+			DBG("Error reading blacklist data '%s'",
+				blacklist_file);
+			r = -EIO;
+			goto out;
+			break;
+
+		}
+	}
+
+	r = 0;
+
+out:
+	if (data)
+		blacklist_data_free(data);
+	if (chan)
+		g_io_channel_unref(chan);
+	if (elem)
+		g_ptr_array_unref(elem);
+
+	return r;
+}
+
+/* O(n) is poor form, but it's expected there's not much data, and
+   storing the data in a more complex format has its own cost as
+   well. */
+
+static gboolean blacklist_match_under(const gchar *path,
+				struct blacklist_data *data)
+{
+	gsize i;
+
+	DBG("Checking '%s' under '%s'", path, data->path);
+
+	for (i = 0; i < data->elem->len; i++) {
+		gchar *check = data->elem->pdata[i];
+		gsize check_len = strlen(check);
+
+		if (g_str_has_prefix(path, check) &&
+			(path[check_len] == '\0' ||
+				path[check_len] == G_DIR_SEPARATOR)) {
+			DBG("'%s' matches '%s'", path, check);
+			return TRUE;
+		}
+	}
+
+	DBG("No match.");
+	return FALSE;
+}
+
+static gboolean blacklist_match(const gchar *raw_path)
+{
+	GSList *b;
+	gchar *path;
+	gboolean r = FALSE;
+
+	DBG("'%s'", raw_path);
+	path = normalized_path(raw_path);
+	if (!path)
+		goto out;
+
+	for (b = blacklists; b; b = b->next) {
+		struct blacklist_data *data = b->data;
+		gsize path_len = strlen(data->path);
+
+		if (g_str_has_prefix(path, data->path) &&
+				path[path_len] == G_DIR_SEPARATOR) {
+			const gchar *subpath = &path[path_len + 1];
+			if (blacklist_match_under(subpath, data)) {
+				r = TRUE;
+				goto out;
+			}
+		}
+	}
+
+	DBG("No match.");
+
+out:
+	g_free(path);
+	return r;
+}
+
+static void blacklist_config_free(struct blacklist_config *config)
+{
+	g_free(config->storage_path);
+	g_free(config->blacklist_file);
+	g_free(config);
+}
+
+static void start_storage(struct parser_state *state,
+				const gchar **attr_name,
+				const gchar **attr_value,
+				GError **error)
+{
+	int i;
+
+	for (i = 0; attr_name[i]; i++) {
+		if (!strcasecmp(attr_name[i], "path")) {
+			if (state->storage_path) {
+				*error = g_error_new(G_MARKUP_ERROR,
+						G_MARKUP_ERROR_INVALID_CONTENT,
+						"Duplicate path attribute");
+				return;
+			}
+			if (attr_value[i][0] != G_DIR_SEPARATOR) {
+				*error = g_error_new(G_MARKUP_ERROR,
+						G_MARKUP_ERROR_INVALID_CONTENT,
+						"Relative path");
+				return;
+			}
+			state->storage_path = trimmed_string(attr_value[i]);
+		} else if (!strcasecmp(attr_name[i], "name")) {
+			/* Ignore */
+		} else if (!strcasecmp(attr_name[i], "description")) {
+			/* Ignore */
+		} else if (!strcasecmp(attr_name[i], "blockdev")) {
+			/* Ignore */
+		} else if (!strcasecmp(attr_name[i], "removable")) {
+			/* Ignore */
+		} else {
+			*error = g_error_new(G_MARKUP_ERROR,
+					G_MARKUP_ERROR_UNKNOWN_ATTRIBUTE,
+					"Unknown attribute '%s'", attr_name[i]);
+			return;
+		}
+	}
+}
+
+static void end_storage(struct parser_state *state,
+				GError **error)
+{
+	DBG("storage path: '%s'", state->storage_path);
+	g_free(state->storage_path);
+	state->storage_path = NULL;
+}
+
+static void start_blacklist(struct parser_state *state,
+				const gchar **attr_name,
+				const gchar **attr_value,
+				GError **error)
+{
+	if (attr_name[0]) {
+		*error = g_error_new(G_MARKUP_ERROR,
+				G_MARKUP_ERROR_UNKNOWN_ATTRIBUTE,
+				"Unknown attribute '%s'", attr_name[0]);
+		return;
+	}
+
+	if (!state->storage_path) {
+		*error = g_error_new(G_MARKUP_ERROR,
+				G_MARKUP_ERROR_MISSING_ATTRIBUTE,
+				"Missing path but <blacklist> present");
+		return;
+	}
+}
+
+static void end_blacklist(struct parser_state *state,
+				GError **error)
+{
+	struct blacklist_config *config = NULL;
+
+	if (!state->blacklist_file) {
+		*error = g_error_new(G_MARKUP_ERROR,
+				G_MARKUP_ERROR_INVALID_CONTENT,
+				"Missing blacklist file definition");
+		return;
+	}
+
+	DBG("blacklist file: '%s'", state->blacklist_file);
+	config = g_new0(struct blacklist_config, 1);
+	config->storage_path = g_strdup(state->storage_path);
+	config->blacklist_file = trimmed_string(state->blacklist_file);
+	g_free(state->blacklist_file);
+	state->blacklist_file = NULL;
+	state->configs = g_slist_append(state->configs, config);
+}
+
+static void xml_start_element(GMarkupParseContext *context,
+				const gchar *element_name,
+				const gchar **attr_names,
+				const gchar **attr_values,
+				gpointer user_data,
+				GError **error)
+{
+	enum config_elem from, to;
+	struct parser_state *state = user_data;
+	int i;
+
+	DBG("[%d] <%s>", (int)state->pos, element_name);
+
+	if (state->pos == PARSER_STACK_MAX) {
+		*error = g_error_new(G_MARKUP_ERROR,
+					G_MARKUP_ERROR_INVALID_CONTENT,
+					"Stack overflow");
+		return;
+	} else if (state->pos == 0) {
+		*error = g_error_new(G_MARKUP_ERROR,
+					G_MARKUP_ERROR_INVALID_CONTENT,
+					"Bad stack");
+		return;
+	}
+
+	for (i = CONFIG_ELEM_STORAGE; i < N_CONFIG_ELEM; i++) {
+		if (!strcasecmp(element_name, config_elem_name[i])) {
+			to = i;
+			break;
+		}
+	}
+	if (i == N_CONFIG_ELEM) {
+		*error = g_error_new(G_MARKUP_ERROR,
+					G_MARKUP_ERROR_UNKNOWN_ELEMENT,
+					"Unknown element '%s'", element_name);
+		return;
+	}
+
+	from = state->stack[state->pos - 1];
+
+	if (start_transition[from][to] == NULL) {
+		*error = g_error_new(G_MARKUP_ERROR,
+					G_MARKUP_ERROR_INVALID_CONTENT,
+					"<%s> inside <%s> not allowed",
+					element_name,
+					config_elem_name[from]);
+		return;
+	}
+
+	state->stack[state->pos++] = to;
+	(start_transition[from][to])(state, attr_names, attr_values, error);
+}
+
+static void xml_end_element(GMarkupParseContext *context,
+				const gchar *element_name,
+				gpointer user_data,
+				GError **error)
+{
+	struct parser_state *state = user_data;
+
+	DBG("[%d] </%s>", (int)state->pos, element_name);
+
+	if (state->pos == 0) {
+		*error = g_error_new(G_MARKUP_ERROR,
+					G_MARKUP_ERROR_INVALID_CONTENT,
+					"Stack underflow");
+		return;
+	}
+
+	state->pos--;
+	(end_transition[state->stack[state->pos]])(state, error);
+}
+
+static void xml_text(GMarkupParseContext *context,
+			const gchar *text,
+			gsize text_len,
+			gpointer user_data,
+			GError **error)
+{
+	struct parser_state *state = user_data;
+
+	if (state->pos > 0 &&
+			state->stack[state->pos - 1] == CONFIG_ELEM_BLACKLIST) {
+		gsize curr_len = state->blacklist_file
+			? strlen(state->blacklist_file)
+			: 0;
+		state->blacklist_file = g_realloc(state->blacklist_file,
+						curr_len + text_len + 1);
+		memcpy(&state->blacklist_file[curr_len], text, text_len + 1);
+		
+	} else {
+		/* Whitespace is ignored; anything else triggers an error */
+		gsize i;
+		for (i = 0; i < text_len; i++) {
+			if (!g_ascii_isspace(text[i])) {
+				*error = g_error_new(G_MARKUP_ERROR,
+						G_MARKUP_ERROR_INVALID_CONTENT,
+						"Unexpected text %.*s",
+						(int)text_len, text);
+				return;
+			}
+		}
+	}
+}
+
+static void xml_passthru(GMarkupParseContext *context,
+				const gchar *text,
+				gsize text_len,
+				gpointer user_data,
+				GError **error)
+{
+	struct parser_state *state = user_data;
+
+	/* CDATA inside the document not supported */
+	if (state->pos > 0 && state->stack[state->pos - 1] != CONFIG_ELEM_ROOT) {
+		*error = g_error_new(G_MARKUP_ERROR,
+				G_MARKUP_ERROR_INVALID_CONTENT,
+				"Unexpected CDATA %.*s", (int)text_len, text);
+		return;
+	}
+}
+
+static int append_config(const gchar *config_file)
+{
+	GMarkupParser parser = {
+		.start_element = xml_start_element,
+		.end_element = xml_end_element,
+		.text = xml_text,
+		.passthrough = xml_passthru,
+		.error = NULL
+	};
+	struct parser_state state = {
+		.pos = 0,
+		.storage_path = NULL,
+		.blacklist_file = NULL,
+		.configs = NULL
+	};
+	GMarkupParseContext *ctxt = NULL;
+	gchar *buf = NULL;
+	gsize len = 0;
+	int r = -1;
+	GSList *l;
+	GError *error = NULL;
+
+	if (!g_file_get_contents(config_file, &buf, &len, NULL)) {
+		DBG("Cannot read configuration file '%s'", config_file);
+		r = -EIO;
+		goto out;
+	}
+
+	DBG("Opened configuration file '%s'", config_file);
+
+	state.stack[state.pos++] = CONFIG_ELEM_ROOT;
+
+	ctxt = g_markup_parse_context_new(&parser, 0, &state, NULL);
+	if (!ctxt) {
+		DBG("Cannot create XML parser");
+		r = -EINVAL;
+		goto out;
+	}
+	
+	if (!g_markup_parse_context_parse(ctxt, buf, len, &error) ||
+		!g_markup_parse_context_end_parse(ctxt, &error)) {
+		DBG("Cannot parse configuration file '%s': %s",
+			config_file, error->message);
+		g_error_free(error);
+		r = -EINVAL;
+		goto out;
+	}
+
+	DBG("Parsed XML configuration file '%s'", config_file);
+
+	/* Only add blacklist data after successful XML parsing */
+	for (l = state.configs; l; l = l->next) {
+		struct blacklist_config *config = l->data;
+		r = blacklist_add(config->storage_path, config->blacklist_file);
+		if (r < 0)
+			goto out;
+	}
+
+	r = 0;
+
+out:
+	g_free(state.storage_path);
+	g_free(state.blacklist_file);
+	g_slist_free_full(state.configs, (GDestroyNotify)blacklist_config_free);
+
+	if (ctxt)
+		g_markup_parse_context_free(ctxt);
+
+	g_free(buf);
+
+	return r;
+}
+
+static int jolla_blacklist_check(const uint8_t *target,
+					gsize target_len,
+					enum access_op op,
+					const gchar *object,
+					gpointer user_data)
+{
+	/* Don't care which target is used; don't care which op is used */
+	if (blacklist_match(object))
+		return -EPERM;
+	return 0;
+}
+
+static int jolla_blacklist_check_at(const uint8_t *target,
+					gsize target_len,
+					enum access_op op,
+					const gchar *parent,
+					const gchar *object,
+					gpointer user_data)
+{
+	gchar *path = g_build_filename(parent, object, NULL);
+	int r = jolla_blacklist_check(target, target_len, op, path, user_data);
+	g_free(path);
+	return r;
+}
+
+struct access_plugin jolla_blacklist_plugin = {
+	jolla_blacklist_check,
+	jolla_blacklist_check_at
+};
+
+static int jolla_blacklist_init(void)
+{
+	const gchar *name;
+	gchar *path = config_dir ? config_dir : CONFIG_DIR;
+	GDir *dir = NULL;
+	int r;
+
+	if (!g_file_test(path, G_FILE_TEST_IS_DIR)) {
+		DBG("Cannot open configuration directory '%s'", path);
+		r = -EIO;
+		goto out;
+	}
+
+	dir = g_dir_open(path, 0, NULL);
+	if (!dir) {
+		DBG("Cannot open configuration directory '%s'", path);
+		r = -EIO;
+		goto out;
+	}
+
+	while ((name = g_dir_read_name(dir)) != NULL) {
+		int len = strlen(name);
+		if (len > CONFIG_SUFFIX_LEN &&
+			!strcasecmp(name + len - CONFIG_SUFFIX_LEN,
+					CONFIG_SUFFIX)) {
+			gchar *config_file = g_build_filename(path, name, NULL);
+			r = append_config(config_file);
+			if (r < 0) {
+				DBG("Cannot append config '%s'", config_file);
+				goto out;
+			}
+			g_free(config_file);
+		}
+	}
+
+	r = access_plugin_register("jolla_blacklist",
+					&jolla_blacklist_plugin,
+					NULL);
+	if (r < 0) {
+		DBG("Cannot register access plugin");
+		goto out;
+	}
+
+	DBG("Blacklist configuration done.");
+	blacklist_debug();
+
+	r = 0;
+
+out:
+	if (dir)
+		g_dir_close(dir);
+
+	if (r < 0) {
+		blacklist_clear();
+	}
+
+	return r;
+}
+
+static void jolla_blacklist_exit(void)
+{
+	access_plugin_unregister("jolla_blacklist");
+	blacklist_clear();
+}
+
+OBEX_PLUGIN_DEFINE(jolla_blacklist, jolla_blacklist_init, jolla_blacklist_exit)

--- a/obexd/src/access.c
+++ b/obexd/src/access.c
@@ -1,0 +1,98 @@
+/*
+ *  Access control functionality
+ *
+ *  Copyright (C) 2015 Jolla Ltd.
+ *  Contact: Hannu Mallat <hannu.mallat@jollamobile.com>
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdint.h>
+
+#include <glib.h>
+
+#include "log.h"
+#include "access.h"
+
+static char *plugin_name = NULL;
+static struct access_plugin *plugin_ptr = NULL;
+static gpointer plugin_data = NULL;
+
+int access_plugin_register(const char *name,
+			struct access_plugin *plugin,
+			gpointer user_data)
+{
+	if (!name || !plugin || !plugin->check || !plugin->check_at)
+		return -EINVAL;
+
+	if (plugin_name)
+		return -EALREADY;
+
+	plugin_name = g_strdup(name);
+	plugin_ptr = plugin;
+	plugin_data = user_data;
+
+	return 0;
+}
+
+int access_plugin_unregister(const char *name)
+{
+	if (!name || !plugin_name || strcmp(name, plugin_name))
+		return -ENOENT;
+
+	g_free(plugin_name);
+	plugin_name = NULL;
+	plugin_ptr = NULL;
+	plugin_data = NULL;
+
+	return 0;
+}
+
+int access_check(const uint8_t *target,
+			gsize target_len,
+			enum access_op op,
+			const gchar *object)
+{
+	if (plugin_ptr)
+		return (plugin_ptr->check)(target, target_len, op, object,
+					plugin_data);
+	else
+		return 0;
+}
+
+int access_check_at(const uint8_t *target,
+			gsize target_len,
+			enum access_op op,
+			const gchar *parent,
+			const gchar *object)
+{
+	if (plugin_ptr)
+		return (plugin_ptr->check_at)(target, target_len, op, parent,
+					object, plugin_data);
+	else
+		return 0;
+}
+

--- a/obexd/src/access.h
+++ b/obexd/src/access.h
@@ -1,0 +1,77 @@
+/*
+ *  Access control functionality
+ *
+ *  Copyright (C) 2015 Jolla Ltd.
+ *  Contact: Hannu Mallat <hannu.mallat@jollamobile.com>
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/*
+ * Functions for checking access to filesystem objects and and
+ * interface for access plugins to provide the implementation for
+ * custom access checks.  Intended for cases where file system based
+ * access controls are not enough (e.g., when it's not desirable to
+ * export all of user's files over OBEX FTP)
+ */
+
+enum access_op {
+	ACCESS_OP_LIST,
+	ACCESS_OP_READ,
+	ACCESS_OP_WRITE,
+	ACCESS_OP_CREATE,
+	ACCESS_OP_DELETE
+};
+
+struct access_plugin {
+	int (*check)(const uint8_t *target,
+			gsize target_len,
+			enum access_op op,
+			const gchar *object,
+			gpointer user_data);
+	int (*check_at)(const uint8_t *target,
+			gsize target_len,
+			enum access_op op,
+			const gchar *parent,
+			const gchar *object,
+			gpointer user_data);
+};
+
+/*
+ * It is possible to register only one plugin at a time; if a plugin
+ * is already registered when a new registration is attempted, the
+ * attempt will fail.
+ *
+ * If no plugin is registered, all operations are allowed.
+ *
+ */
+int access_plugin_register(const char *name,
+			struct access_plugin *plugin,
+			gpointer user_data);
+
+int access_plugin_unregister(const char *name);
+
+int access_check(const uint8_t *target,
+			gsize target_len,
+			enum access_op op,
+			const gchar *object);
+
+int access_check_at(const uint8_t *target,
+			gsize target_len,
+			enum access_op op,
+			const gchar *parent,
+			const gchar *object);

--- a/obexd/unit/test-jolla-blacklist.c
+++ b/obexd/unit/test-jolla-blacklist.c
@@ -1,0 +1,587 @@
+/*
+ *  Blacklist based file access control, unit tests
+ *
+ *  Copyright (C) 2015 Jolla Ltd.
+ *  Contact: Hannu Mallat <hannu.mallat@jollamobile.com>
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "plugins/jolla-blacklist.c"
+#include <sys/stat.h>
+
+static void test_path_normalization(void)
+{
+	static const char *abs_input[] = {
+		"/",
+		"///",
+
+		"/dir1",
+		"///dir1",
+		"/dir1/",
+
+		"/dir1/dir2",
+		"/dir1///dir2",
+		"/dir1/dir2/",
+
+		"/dir1/./dir2/././dir3",
+		"/dir1/dir2/.",
+		"/dir1/dir2/./",
+
+		"/dir1/dir2/..",
+		"/dir1/dir2/../",
+
+		"/dir1/dir2/dir3/../dir4",
+		"/dir1/dir2/dir3/../dir4/",
+
+		"/dir1/dir2/dir3/../../../../../dir4",
+		"/dir1/dir2/dir3/../../../../../dir4/",
+		"/../../dir1",
+
+		NULL
+	};
+	static const char *abs_expected[] = {
+		"/",
+		"/",
+
+		"/dir1",
+		"/dir1",
+		"/dir1",
+
+		"/dir1/dir2",
+		"/dir1/dir2",
+		"/dir1/dir2",
+
+		"/dir1/dir2/dir3",
+		"/dir1/dir2",
+		"/dir1/dir2",
+
+		"/dir1",
+		"/dir1",
+
+		"/dir1/dir2/dir4",
+		"/dir1/dir2/dir4",
+
+		"/dir4",
+		"/dir4",
+		"/dir1",
+
+		NULL
+	};
+	int i;
+
+	g_assert(normalized_path(NULL) == NULL);
+	g_assert(normalized_path("not/absolute") == NULL);
+
+	for (i = 0; abs_input[i]; i++) {
+		gchar *result = normalized_path(abs_input[i]);
+		g_assert_cmpstr(result, ==, abs_expected[i]);
+		g_free(result);
+	}
+
+}
+
+const gchar *simple_blacklist =
+	".ssh\n"
+	".invisible_file\n"
+	"Music/DRM\n"
+	;
+
+const gchar *trim_blacklist =
+	"\t.ssh\n"
+	"        .invisible_file        \n"
+	"Music/DRM\t\n"
+	"\n"
+	"         \n"
+	"\t"
+	;
+
+const gchar *comment_blacklist =
+	"# this is a test\n"
+	".ssh\n"
+	".invisible_file\n"
+	"# why even have this?\n"
+	"Music/DRM\n"
+	"# close to the end\n"
+	;
+
+static void test_blacklist_reading_valid_blacklists(void)
+{
+	const gchar *test_blacklists[] = {
+		simple_blacklist,
+		trim_blacklist,
+		comment_blacklist,
+		NULL
+	};
+
+	int i;
+
+	blacklist_clear();
+
+	for (i = 0; test_blacklists[i]; i++) {
+		struct blacklist_data *data;
+		char tmplate[] = "/tmp/test-jolla-blacklist.XXXXXX";
+		int fd = mkstemp(tmplate);
+		g_assert_cmpint(fd, >=, 0);
+		g_assert(g_file_set_contents(tmplate,
+						test_blacklists[i],
+						strlen(test_blacklists[i]),
+						NULL) == TRUE);
+		g_assert(blacklist_add("/home/nemo", tmplate) == 0);
+		
+		/* Check data is as expected */
+		g_assert_cmpint(g_slist_length(blacklists), ==, 1);
+		data = blacklists->data;
+		g_assert_cmpstr(data->path, ==, "/home/nemo");
+		g_assert_cmpint(data->elem->len, ==, 3);
+		g_assert_cmpstr(data->elem->pdata[0], ==, ".ssh");
+		g_assert_cmpstr(data->elem->pdata[1], ==, ".invisible_file");
+		g_assert_cmpstr(data->elem->pdata[2], ==, "Music/DRM");
+
+		close(fd);
+		unlink(tmplate);
+
+		blacklist_clear();
+	}
+}
+
+const gchar *home_nemo_blacklist =
+	".ssh\n"
+	".invisible_file\n"
+	"Music/DRM\n"
+	;
+
+const gchar *home_nemo_Documents_blacklist =
+	"Mailbox\n"
+	"Work/Restricted\n"
+	;
+
+const gchar *sdcard_blacklist =
+	"Music/DRM\n"
+	;
+
+static void test_blacklist_matching(void)
+{
+	const gchar *test_blacklists[] = {
+		home_nemo_blacklist,
+		home_nemo_Documents_blacklist,
+		sdcard_blacklist,
+		NULL
+	};
+	const gchar *test_blacklist_roots[] = {
+		"/home/nemo",
+		"/home/nemo/Documents",
+		"/media/sdcard",
+		NULL
+	};
+	const gchar *matching_paths[] = {
+		"/home/nemo/.ssh",
+		"/home/nemo/.ssh/",
+		"/home/nemo/.ssh/./",
+		"/home/nemo/../nemo/.ssh",
+		"/home/nemo/.invisible_file",
+		"/home/nemo/Music/DRM/BoringArtist/BoringAlbum",
+		"/home/nemo/Documents/Mailbox/John_Doe",
+		"/home/nemo/Documents/Work/Restricted/schedule.ppt",
+		"/media/sdcard/Music/DRM/BoringArtist/BoringAlbum",
+
+		NULL
+	};
+	const gchar *non_matching_paths[] = {
+		"/home/nemo",
+		"/home/nemo/.invisible_file2",
+		"/home/nemo/Documents",
+		"/home/nemo/Documents/Shared",
+		"/home/nemo/Music",
+		"/home/nemo/Music/GoodArtist",
+		"/home",
+		"/usr",
+		"/",
+		"/media/sdcard/Music/GoodArtist",
+
+		NULL
+	};
+	int i;
+
+	blacklist_clear();
+
+	for (i = 0; test_blacklists[i]; i++) {
+		char tmplate[] = "/tmp/test-jolla-blacklist.XXXXXX";
+		int fd = mkstemp(tmplate);
+		g_assert_cmpint(fd, >=, 0);
+		g_assert(g_file_set_contents(tmplate,
+						test_blacklists[i],
+						strlen(test_blacklists[i]),
+						NULL) == TRUE);
+		g_assert(blacklist_add(test_blacklist_roots[i], tmplate) == 0);
+
+		close(fd);
+		unlink(tmplate);
+	}
+
+	for (i = 0; matching_paths[i]; i++)
+		g_assert(blacklist_match(matching_paths[i]) == TRUE);
+
+	for (i = 0; non_matching_paths[i]; i++)
+		g_assert(blacklist_match(non_matching_paths[i]) == FALSE);
+
+	g_assert(blacklist_match(NULL) == FALSE);
+	g_assert(blacklist_match("not/absolute/path") == FALSE);
+
+	blacklist_clear();
+}
+
+static gchar *setup_config_dir(const gchar *xml_fmt,
+			const char *list_name,
+			const char *list_data)
+{
+	char tmpdir[] = "/tmp/test-jolla-blacklist-config.XXXXXX";
+	gchar *fname = NULL;
+	gchar *buf = NULL;
+
+	g_assert(mkdtemp(tmpdir) != NULL);
+
+	fname = g_build_filename(tmpdir, "test.xml", NULL);
+	buf = g_strdup_printf(xml_fmt, tmpdir);
+	DBG("%s", buf);
+	g_assert(g_file_set_contents(fname, buf, strlen(buf), NULL) == TRUE);
+	g_free(buf);
+	g_free(fname);
+	fname = g_build_filename(tmpdir, list_name, NULL);
+	g_assert(g_file_set_contents(fname, list_data,
+					strlen(list_data), NULL) == TRUE);
+	g_free(fname);
+
+	return g_strdup(tmpdir);
+}
+
+static void cleanup_config_dir(gchar *dirname)
+{
+	const gchar *name;
+	GDir *dir;
+
+	dir = g_dir_open(dirname, 0, NULL);
+	while ((name = g_dir_read_name(dir)) != NULL) {
+		gchar *fullname = g_build_filename(dirname, name, NULL);
+		unlink(fullname);
+		g_free(fullname);
+	}
+	g_dir_close(dir);
+	rmdir(dirname);
+	g_free(dirname);
+}
+
+static void test_blacklist_reading_valid_xml(void)
+{
+}
+
+static void test_blacklist_reading_invalid_xml(void)
+{
+	static const gchar *bad_xml[] = {
+		/* Relative storage path */
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		"<storage path=\"not/absolute\" name=\"media\">\n"
+		"  <blacklist>%s/test.conf</blacklist>\n"
+		"</storage>\n",
+
+		/* Missing storage path */
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		"<storage name=\"media\">\n"
+		"  <blacklist>%s/test.conf</blacklist>\n"
+		"</storage>\n",
+
+		/* Duplicate storage path */
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		"<storage path=\"/home/nemo\" path=\"/home/nemo\">\n"
+		"  <blacklist>%s/test.conf</blacklist>\n"
+		"</storage>\n",
+
+		/* Unknown storage attribute */
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		"<storage name=\"Test\" path=\"/home/nemo\" foo=\"bar\">\n"
+		"  <blacklist>%s/test.conf</blacklist>\n"
+		"</storage>\n",
+
+		/* Unknown blacklist attribute */
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		"<storage name=\"Test\" path=\"/home/nemo\">\n"
+		"  <blacklist foo=\"bar\">%s/test.conf</blacklist>\n"
+		"</storage>\n",
+
+		/* Missing blacklist data */
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		"<storage name=\"Test\" path=\"/home/nemo\">\n"
+		"  <blacklist></blacklist>\n"
+		"</storage>\n",
+
+		/* Missing blacklist data (all whitespace) */
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		"<storage name=\"Test\" path=\"/home/nemo\">\n"
+		"  <blacklist>        </blacklist>\n"
+		"</storage>\n",
+
+		/* Unknown element */
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		"<storage name=\"Test\" path=\"/home/nemo\">\n"
+		"  <blacklist>%s/test.conf</blacklist>\n"
+		"  <whitelist>foo.conf</whitelist>\n"
+		"</storage>\n",
+
+		/* Bad nesting */
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		"<storage name=\"Test\" path=\"/home/nemo\">\n"
+		"  <storage name=\"Test\" path=\"/home/nemo\">\n"
+		"    <blacklist>%s/test.conf</blacklist>\n"
+		"  </storage>\n"
+		"</storage>\n",
+
+		/* Unexpected text */
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		"<storage name=\"Test\" path=\"/home/nemo\">\n"
+		"  dummy\n"
+		"  <blacklist>%s/test.conf</blacklist>\n"
+		"</storage>\n",
+
+		NULL
+	};
+	static const gchar *blacklist =
+		".foo\n"
+		".bar\n"
+		".baz\n"
+		;
+	static const gchar *blackfile = "test.conf";
+	int i;
+
+	blacklist_clear();
+
+	for (i = 0; bad_xml[i]; i++) {
+		gchar *dirname = NULL;
+		gchar *pathname = NULL;
+		dirname = setup_config_dir(bad_xml[i], blackfile, blacklist);
+		config_dir = dirname;
+		pathname = g_build_filename(dirname, "test.xml", NULL);
+		g_assert_cmpint(append_config(pathname), !=, 0);
+		g_assert(blacklists == NULL);
+		g_free(pathname);
+		cleanup_config_dir(dirname);
+	}
+}
+
+static void test_init_filled(void)
+{
+	static const gchar *test_xml_fmt =
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		"<storage name=\"media\" path=\"/home/nemo\"\n"
+		"         description=\"Phone Memory\">\n"
+		"<blacklist>%s/blacklist-home.conf</blacklist>\n"
+		"</storage>\n"
+		;
+	static const gchar *test_blacklist =
+		".foo\n"
+		".bar\n"
+		".baz\n"
+		;
+	static const gchar *test_blackfile = "blacklist-home.conf";
+	gchar *dirname = NULL;
+
+	dirname = setup_config_dir(test_xml_fmt, test_blackfile, test_blacklist);
+	config_dir = dirname;
+	g_assert_cmpint(jolla_blacklist_init(), ==, 0);
+
+	/* Check that plugin gets called */
+	g_assert_cmpint(access_check(NULL, 0, ACCESS_OP_LIST, "/home/nemo/.foo"),
+			!=, 0);
+	g_assert_cmpint(access_check(NULL, 0, ACCESS_OP_LIST, "/home/nemo/.xyz"),
+			==, 0);
+	g_assert_cmpint(access_check_at(NULL, 0, ACCESS_OP_LIST, "/home/nemo", ".foo"),
+			!=, 0);
+	g_assert_cmpint(access_check_at(NULL, 0, ACCESS_OP_LIST, "/home/nemo", ".xyz"),
+			==, 0);
+
+	jolla_blacklist_exit();
+	cleanup_config_dir(dirname);
+}
+
+static void test_init_empty(void)
+{
+	char tmpdir[] = "/tmp/test-jolla-blacklist-config.XXXXXX";
+
+	g_assert(mkdtemp(tmpdir) != NULL);
+	config_dir = tmpdir;
+	g_assert_cmpint(jolla_blacklist_init(), ==, 0);
+	jolla_blacklist_exit();
+	unlink(tmpdir);
+}
+
+static void test_init_nonexistent(void)
+{
+	g_assert_cmpint(jolla_blacklist_init(), !=, 0);
+}
+
+static void test_init_error(void)
+{
+	char tmpdir[] = "/tmp/test-jolla-blacklist-config.XXXXXX";
+
+	g_assert(mkdtemp(tmpdir) != NULL);
+	config_dir = tmpdir;
+	chmod(tmpdir, 0220); /* Remove r and x to trigger error */
+	g_assert_cmpint(jolla_blacklist_init(), !=, 0);
+	unlink(tmpdir);
+}
+
+static void test_init_double(void)
+{
+	char tmpdir[] = "/tmp/test-jolla-blacklist-config.XXXXXX";
+
+	g_assert(mkdtemp(tmpdir) != NULL);
+	config_dir = tmpdir;
+	g_assert_cmpint(jolla_blacklist_init(), ==, 0);
+	g_assert_cmpint(jolla_blacklist_init(), !=, 0);
+	jolla_blacklist_exit();
+	unlink(tmpdir);
+}
+
+#define DUMMY_USER_DATA 12345
+
+static int dummy_access_check(const uint8_t *target,
+				gsize target_len,
+				enum access_op op,
+				const gchar *object,
+				gpointer user_data)
+{
+	return GPOINTER_TO_INT(user_data) == DUMMY_USER_DATA ? 0 : -EPERM;
+}
+
+static int dummy_access_check_at(const uint8_t *target,
+				gsize target_len,
+				enum access_op op,
+				const gchar *parent,
+				const gchar *object,
+				gpointer user_data)
+{
+	return GPOINTER_TO_INT(user_data) == DUMMY_USER_DATA ? 0 : -EPERM;
+}
+
+static void test_access_plugin_reg(void)
+{
+	struct access_plugin p = {
+		dummy_access_check, dummy_access_check_at
+	};
+	struct access_plugin b1 = {
+		NULL, dummy_access_check_at
+	};
+	struct access_plugin b2 = {
+		dummy_access_check, NULL
+	};
+	struct access_plugin b3 = {
+		NULL, NULL
+	};
+
+	/* Normal case */
+	g_assert_cmpint(access_plugin_register("dummy", &p, NULL), ==, 0);
+	g_assert_cmpint(access_plugin_unregister("dummy"), ==, 0);
+
+	/* Bad param reg must fail */
+	g_assert_cmpint(access_plugin_register("dummy", NULL, NULL), !=, 0);
+	g_assert_cmpint(access_plugin_register(NULL, &p, NULL), !=, 0);
+	g_assert_cmpint(access_plugin_register(NULL, NULL, NULL), !=, 0);
+	g_assert_cmpint(access_plugin_register("dummy", &b1, NULL), !=, 0);
+	g_assert_cmpint(access_plugin_register("dummy", &b2, NULL), !=, 0);
+	g_assert_cmpint(access_plugin_register("dummy", &b3, NULL), !=, 0);
+
+	/* Double reg must fail */
+	g_assert_cmpint(access_plugin_register("dummy", &p, NULL), ==, 0);
+	g_assert_cmpint(access_plugin_register("dummy2", &p, NULL), !=, 0);
+	g_assert_cmpint(access_plugin_unregister("dummy"), ==, 0);
+
+	/* Wrong unreg must fail */
+	g_assert_cmpint(access_plugin_register("dummy", &p, NULL), ==, 0);
+	g_assert_cmpint(access_plugin_unregister("nondummy"), !=, 0);
+	g_assert_cmpint(access_plugin_unregister("dummy"), ==, 0);
+
+	/* Nonexistent unreg must fail */
+	g_assert_cmpint(access_plugin_unregister("dummy"), !=, 0);
+}
+
+static void test_access_plugin_check(void)
+{
+	struct access_plugin p = {
+		dummy_access_check, dummy_access_check_at
+	};
+	enum access_op op[] = {
+		ACCESS_OP_LIST,
+		ACCESS_OP_READ,
+		ACCESS_OP_WRITE,
+		ACCESS_OP_CREATE,
+		ACCESS_OP_DELETE
+	};
+	int i;
+
+	/* Checks without plugin must succeed */
+	for (i = 0; i < 5; i++)
+		g_assert_cmpint(access_check(NULL, 0, op[i], "/home/nemo/foo"),
+				==,
+				0);
+	for (i = 0; i < 5; i++)
+		g_assert_cmpint(access_check_at(NULL, 0, op[i], "/home",
+								"nemo/foo"),
+				==,
+				0);
+
+	/* Checks with plugin must go through to the plugin functions */
+	g_assert_cmpint(access_plugin_register("dummy", &p, GINT_TO_POINTER(DUMMY_USER_DATA)), ==, 0);
+	g_assert_cmpint(access_check(NULL, 0, op[i], "/home/nemo/foo"), ==, 0);
+	g_assert_cmpint(access_check_at(NULL, 0, op[i], "/home", "nemo/foo"),
+				==,
+				0);
+	g_assert_cmpint(access_plugin_unregister("dummy"), ==, 0);
+}
+
+int main(int argc, char *argv[])
+{
+	__obex_log_init(argv[0], "-d", FALSE);
+	__obex_log_enable_debug();
+
+	g_test_init(&argc, &argv, NULL);
+
+	g_test_add_func("/access/plugin/register", test_access_plugin_reg);
+	g_test_add_func("/access/plugin/check", test_access_plugin_check);
+
+	g_test_add_func("/blacklist/init/empty", test_init_empty);
+	g_test_add_func("/blacklist/init/nonexistent", test_init_nonexistent);
+	g_test_add_func("/blacklist/init/filled", test_init_filled);
+	g_test_add_func("/blacklist/init/error", test_init_error);
+	g_test_add_func("/blacklist/init/double", test_init_double);
+
+	g_test_add_func("/blacklist/filenames/test_path_normalization",
+			test_path_normalization);
+
+	g_test_add_func("/blacklist/datafiles/test_reading_valid_blacklists",
+			test_blacklist_reading_valid_blacklists);
+
+	g_test_add_func("/blacklist/xmlfiles/test_reading_valid_xml",
+			test_blacklist_reading_valid_xml);
+	g_test_add_func("/blacklist/xmlfiles/test_reading_invalid_xml",
+			test_blacklist_reading_invalid_xml);
+
+	g_test_add_func("/blacklist/matching/test_matches",
+			test_blacklist_matching);
+
+	g_test_run();
+
+	return 0;
+}

--- a/rpm/obexd.spec
+++ b/rpm/obexd.spec
@@ -46,6 +46,7 @@ Development files for %{name}.
 sed -i 's/ovi_suite/pc_suite/' plugins/usb.c
 %reconfigure --disable-static \
     --enable-usb --enable-pcsuite \
+    --enable-jolla-blacklist \
     --with-phonebook=sailfish \
     --with-contentfilter=helperapp
 


### PR DESCRIPTION
PR implements a plugin based API for access checking of OBEX operations; takes API into use for the filesystem plugin; and implements a blacklist plugin for the API, so that FTP operations can be limited by a blacklist configuration.

For blacklisted files/directories get, put, delete and rename operations will be blocked, and they will not show up in directory listing of their parent directory. Blacklisted directories cannot cannot be listed or cd'd into.
