### PR TITLE
[obexd] Compilation with coverage information

### DIFF
--- a/obexd/acinclude.m4
+++ b/obexd/acinclude.m4
@@ -32,5 +32,9 @@ AC_DEFUN([COMPILER_FLAGS], [
 		CFLAGS="$CFLAGS -Wredundant-decls"
 		CFLAGS="$CFLAGS -Wcast-align"
 		CFLAGS="$CFLAGS -DG_DISABLE_DEPRECATED"
+		if (test "$enable_coverage" = "yes"); then
+			CFLAGS="$CFLAGS --coverage -g -O0"
+			LDFLAGS="$LDFLAGS --coverage"
+		fi
 	fi
 ])

--- a/obexd/configure.ac
+++ b/obexd/configure.ac
@@ -25,6 +25,11 @@ fi
 AC_DEFINE_UNQUOTED(CONFIGDIR, "${configdir}",
 				[Directory for the configuration files])
 
+if (test "$USE_MAINTAINER_MODE" = "yes"); then
+	AC_CHECK_PROG(enable_coverage, [gcov], [yes], [no])
+fi
+AM_CONDITIONAL(COVERAGE, test "${enable_coverage}" = "yes")
+
 COMPILER_FLAGS
 
 AC_LANG_C

--- a/obexd/plugins/ftp.c
+++ b/obexd/plugins/ftp.c
@@ -22,6 +22,8 @@
  *
  */
 
+#define _GNU_SOURCE
+
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif

--- a/obexd/plugins/opp.c
+++ b/obexd/plugins/opp.c
@@ -22,6 +22,8 @@
  *
  */
 
+#define _GNU_SOURCE
+
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif

--- a/obexd/plugins/pbap.c
+++ b/obexd/plugins/pbap.c
@@ -260,7 +260,7 @@ static void query_result(const char *buffer, size_t bufsize, int vcards,
 {
 	struct pbap_session *pbap = user_data;
 
-	DBG("size=%d, vcards=%d, lastpart=%s",
+	DBG("size=%zd, vcards=%d, lastpart=%s",
 		bufsize, vcards, lastpart ? "yes" : "no");
 
 	if (pbap->obj->request && lastpart) {
@@ -573,7 +573,7 @@ static int pbap_get(struct obex_session *os, void *user_data)
 		return -EBADR;
 
 	rsize = obex_get_apparam(os, &buffer);
-	DBG("apparam size %d", rsize);
+	DBG("apparam size %zd", rsize);
 	if (rsize < 0) {
 		if (g_ascii_strcasecmp(type, VCARDENTRY_TYPE) != 0)
 			return -EBADR;

--- a/obexd/plugins/phonebook-sailfish.c
+++ b/obexd/plugins/phonebook-sailfish.c
@@ -326,7 +326,7 @@ static void pull_end(struct phonebook_data *data, gboolean last)
 	data->pull_buf = NULL;
 	data->pull_count = 0;
 
-	DBG("Forwarding %d bytes, %d items (%d new missed calls).",
+	DBG("Forwarding %zd bytes, %d items (%d new missed calls).",
 		buf ? strlen(buf) : 0, count, data->newmissedcalls);
 	data->cb(buf, buf ? strlen(buf) : 0, count,
 		data->newmissedcalls > 0xff ? 0xff : data->newmissedcalls,

--- a/obexd/src/service.h
+++ b/obexd/src/service.h
@@ -33,7 +33,7 @@ struct obex_service_driver {
 	unsigned int target_size;
 	const uint8_t *who;
 	unsigned int who_size;
-	const char *record;
+	char *record;
 	void *(*connect) (struct obex_session *os, int *err);
 	void (*progress) (struct obex_session *os, void *user_data);
 	int (*get) (struct obex_session *os, void *user_data);


### PR DESCRIPTION
Add coverage flag to building when maintainer mode is enabled and gcov
is available.

Also fixed a handful of small warnings that were causing problems with
maintainer mode -Werror compilation.