### PR TITLE
[obexd] Allow excluding services per transport

### DIFF
--- a/obexd/plugins/bluetooth.c
+++ b/obexd/plugins/bluetooth.c
@@ -673,6 +673,7 @@ static int bluetooth_getpeername(GIOChannel *io, char **name)
 
 static struct obex_transport_driver driver = {
 	.name = "bluetooth",
+	.service = OBEX_ALL_SERVICES,
 	.start = bluetooth_start,
 	.getpeername = bluetooth_getpeername,
 	.stop = bluetooth_stop
@@ -682,6 +683,8 @@ static unsigned int listener_id = 0;
 
 static int bluetooth_init(void)
 {
+	uint16_t exclude_mask;
+
 	any = g_new0(struct adapter_any, 1);
 
 	connection = g_dbus_setup_private(DBUS_BUS_SYSTEM, NULL, NULL);
@@ -690,6 +693,10 @@ static int bluetooth_init(void)
 
 	listener_id = g_dbus_add_service_watch(connection, "org.bluez",
 				name_acquired, name_released, NULL, NULL);
+
+	exclude_mask = obex_option_exclude(driver.name);
+	if (exclude_mask)
+		driver.service &= ~exclude_mask;
 
 	return obex_transport_driver_register(&driver);
 }

--- a/obexd/plugins/usb.c
+++ b/obexd/plugins/usb.c
@@ -282,6 +282,7 @@ static struct obex_transport_driver driver = {
 
 static int usb_init(void)
 {
+	uint16_t exclude_mask;
 	struct sigaction sa;
 
 	memset(&sa, 0, sizeof(sa));
@@ -292,6 +293,10 @@ static int usb_init(void)
 	connection = g_dbus_setup_private(DBUS_BUS_SYSTEM, NULL, NULL);
 	if (connection == NULL)
 		return -EPERM;
+
+	exclude_mask = obex_option_exclude(driver.name);
+	if (exclude_mask)
+		driver.service &= ~exclude_mask;
 
 	return obex_transport_driver_register(&driver);
 }

--- a/obexd/src/main.c
+++ b/obexd/src/main.c
@@ -140,6 +140,7 @@ static char *option_root_setup = NULL;
 static char *option_capability = NULL;
 static char *option_plugin = NULL;
 static char *option_noplugin = NULL;
+static char *option_exclude = NULL;
 
 static gboolean option_autoaccept = FALSE;
 static gboolean option_symlinks = FALSE;
@@ -181,6 +182,9 @@ static GOptionEntry options[] = {
 				"Specify plugins to load", "NAME,..." },
 	{ "noplugin", 'P', 0, G_OPTION_ARG_STRING, &option_noplugin,
 				"Specify plugins not to load", "NAME,..." },
+	{ "exclude", 'e', 0, G_OPTION_ARG_STRING, &option_exclude,
+				"Specify plugins to expclude for specific "
+				"transports", "TRANSPORT:NAME,..." },
 	{ NULL },
 };
 
@@ -202,6 +206,43 @@ gboolean obex_option_symlinks(void)
 const char *obex_option_capability(void)
 {
 	return option_capability;
+}
+
+uint16_t obex_option_exclude(const char *transport)
+{
+	uint16_t mask = 0;
+	gchar **excludes = NULL;
+	gsize i, transport_len = strlen(transport);
+
+	if (!option_exclude)
+		return 0;
+
+	excludes = g_strsplit(option_exclude, ",", 0);
+	for (i = 0; excludes[i]; i++) {
+		if (g_str_has_prefix(excludes[i], transport) &&
+			excludes[i][transport_len] == ':') {
+			gchar *plugin = &excludes[i][transport_len + 1];
+			if (!strcasecmp(plugin, "opp"))
+				mask |= OBEX_OPP;
+			else if (!strcasecmp(plugin, "ftp"))
+				mask |= OBEX_FTP;
+			else if (!strcasecmp(plugin, "bip"))
+				mask |= OBEX_BIP;
+			else if (!strcasecmp(plugin, "pbap"))
+				mask |= OBEX_PBAP;
+			else if (!strcasecmp(plugin, "irmc"))
+				mask |= OBEX_IRMC;
+			else if (!strcasecmp(plugin, "pcsuite"))
+				mask |= OBEX_PCSUITE;
+			else if (!strcasecmp(plugin, "syncevolution"))
+				mask |= OBEX_SYNCEVOLUTION;
+			else if (!strcasecmp(plugin, "mas"))
+				mask |= OBEX_MAS;
+		}
+	}
+
+	g_strfreev(excludes);
+	return mask;
 }
 
 static gboolean is_dir(const char *dir) {

--- a/obexd/src/obexd.h
+++ b/obexd/src/obexd.h
@@ -30,6 +30,10 @@
 #define OBEX_SYNCEVOLUTION	(1 << 7)
 #define OBEX_MAS	(1 << 8)
 
+#define OBEX_ALL_SERVICES \
+	(OBEX_OPP | OBEX_FTP | OBEX_BIP | OBEX_PBAP | OBEX_IRMC |\
+		OBEX_PCSUITE | OBEX_SYNCEVOLUTION | OBEX_MAS)
+
 gboolean plugin_init(const char *pattern, const char *exclude);
 void plugin_cleanup(void);
 
@@ -40,3 +44,4 @@ gboolean obex_option_auto_accept(void);
 const char *obex_option_root_folder(void);
 gboolean obex_option_symlinks(void);
 const char *obex_option_capability(void);
+uint16_t obex_option_exclude(const char *transport);

--- a/obexd/src/plugin.c
+++ b/obexd/src/plugin.c
@@ -29,6 +29,7 @@
 #include <dlfcn.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <stdint.h>
 
 #include <glib.h>
 

--- a/obexd/src/server.c
+++ b/obexd/src/server.c
@@ -55,8 +55,7 @@ static void init_server(uint16_t service, GSList *transports)
 		struct obex_server *server;
 		int err;
 
-		if (transport->service != 0 &&
-				(transport->service & service) == FALSE)
+		if ((transport->service & service) == FALSE)
 			continue;
 
 		server = g_new0(struct obex_server, 1);

--- a/rpm/obexd.conf
+++ b/rpm/obexd.conf
@@ -20,6 +20,23 @@ do
   fi
 done
 
+if [ -d /etc/obexd/excludes ]; then
+  EXCLUDES=""
+
+  for EXCLUDE in `find /etc/obexd/excludes -type f`
+  do
+    if [ -z "${EXCLUDES}" ]; then
+      EXCLUDES=`basename "${EXCLUDE}"`
+    else
+      EXCLUDES="${EXCLUDES}",`basename "${EXCLUDE}"`
+    fi
+  done
+
+  if [ ! -z "${EXCLUDES}" ]; then
+    OBEXD_ARGUMENTS="${OBEXD_ARGUMENTS} --exclude=${EXCLUDES}"
+  fi
+fi
+
 if [ -f /etc/obexd/root ]; then
   OBEXROOT=$(eval echo -e `cat /etc/obexd/root`)
   OBEXD_ARGUMENTS="${OBEXD_ARGUMENTS} --root=${OBEXROOT}"


### PR DESCRIPTION
Added a command line option for defining services to exclude for
specific transports. Mostly intended for excluding PC Suite service on
Bluetooth while still keeping it for USB.

By default Bluetooth transport will allow all services and USB
transport will allow PC Suite service as before.