### PR TITLE
[obexd] Configurable PBAP channel. Fixes MER#900.

### DIFF
--- a/obexd/plugins/pbap.c
+++ b/obexd/plugins/pbap.c
@@ -1077,7 +1077,28 @@ static struct obex_mime_type_driver mime_vcard = {
 static int pbap_init(void)
 {
 	int err;
+	GKeyFile *config = NULL;
 
+	config = g_key_file_new();
+	if (config == NULL)
+		goto init;
+
+	if (g_key_file_load_from_file(config, "/etc/obexd/pbap.conf",
+					G_KEY_FILE_NONE, NULL) == TRUE) {
+		gint channel;
+
+		/* returns 0 on error; 0 is also a reserved channel */
+		channel = g_key_file_get_integer(config, "PBAP", "Channel",
+						NULL);
+		if (channel >= 1 && channel <= 30) {
+			DBG("PBAP channel set to %d", channel);
+			pbap.channel = channel;
+		}
+	}
+
+	g_key_file_free(config);
+
+init:
 	err = phonebook_init();
 	if (err < 0)
 		return err;


### PR DESCRIPTION
As some carkits have trouble connecting to the default PBAP channel
15, enable channel configuration for PBAP server.
